### PR TITLE
fix(maps): Server-Key-Trennung + geocode_status-Fix (KM-01, KM-03)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,13 +13,21 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # =============================================================================
 # Google Maps
 # =============================================================================
-# Server-only: Geocoding, Directions API (used by lib/maps/client.ts)
-GOOGLE_MAPS_API_KEY=your-server-api-key
-# Server-only: Referenced by system health checks (actions/system.ts)
-GOOGLE_MAPS_SERVER_API_KEY=your-server-api-key
+# Server key for Web Service calls: Geocoding, Directions, Places Web Service
+# (used by lib/maps/client.ts). MUST NOT have HTTP-referer restrictions —
+# server-to-server requests send no Referer header and Google would reject them
+# with "API keys with referer restrictions cannot be used with this API".
+# In Google Cloud: Application restriction = None (Vercel egress IPs are
+# dynamic); API restriction = Geocoding + Directions + Places only.
+GOOGLE_MAPS_SERVER_API_KEY=your-unrestricted-server-api-key
 
-# Client-only: Places Autocomplete, Static Maps
-NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your-client-api-key
+# DEPRECATED legacy alias — only used as a fallback if GOOGLE_MAPS_SERVER_API_KEY
+# is unset (getApiKey() logs a warning). Prefer GOOGLE_MAPS_SERVER_API_KEY.
+GOOGLE_MAPS_API_KEY=
+
+# Client (browser) key: Maps JavaScript API + Static Maps <img>. This one SHOULD
+# have HTTP-referer restrictions (your domains). Never used for Web Service calls.
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your-referer-restricted-client-api-key
 
 # =============================================================================
 # Email (SMTP) -- used by system health checks (actions/system.ts)

--- a/.env.local.example
+++ b/.env.local.example
@@ -20,8 +20,13 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # =============================================================================
 # Google Maps
 # =============================================================================
-GOOGLE_MAPS_API_KEY=your-server-api-key-here
-NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your-client-api-key-here
+# Server key for Geocoding/Directions/Places Web Service — NO referer restriction
+# (Google Cloud: Application restriction = None, API restriction = those 3 APIs).
+GOOGLE_MAPS_SERVER_API_KEY=your-unrestricted-server-api-key-here
+# Deprecated legacy fallback (only used if GOOGLE_MAPS_SERVER_API_KEY is unset).
+GOOGLE_MAPS_API_KEY=
+# Browser key for Maps JS + Static Maps — SHOULD be referer-restricted.
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your-referer-restricted-client-api-key-here
 
 # =============================================================================
 # Gmail SMTP for driver notifications

--- a/src/actions/system.ts
+++ b/src/actions/system.ts
@@ -90,10 +90,18 @@ export async function getSystemHealth(): Promise<SystemServiceHealth[]> {
     message: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ? "API-Key konfiguriert" : "Nicht konfiguriert",
   })
 
+  // Web-Service-Key (Geocoding/Directions/Places): prefer the dedicated server
+  // key, fall back to the legacy key (see lib/maps/client.ts getApiKey()).
+  const serverMapsKey =
+    process.env.GOOGLE_MAPS_SERVER_API_KEY ?? process.env.GOOGLE_MAPS_API_KEY
   services.push({
     name: "Google Maps (Server)",
-    status: process.env.GOOGLE_MAPS_API_KEY ? "healthy" : "not_configured",
-    message: process.env.GOOGLE_MAPS_API_KEY ? "API-Key konfiguriert" : "Nicht konfiguriert",
+    status: serverMapsKey ? "healthy" : "not_configured",
+    message: process.env.GOOGLE_MAPS_SERVER_API_KEY
+      ? "Server-Key konfiguriert"
+      : process.env.GOOGLE_MAPS_API_KEY
+        ? "Nur veralteter GOOGLE_MAPS_API_KEY (bitte GOOGLE_MAPS_SERVER_API_KEY setzen)"
+        : "Nicht konfiguriert",
   })
 
   // SMTP / Nodemailer
@@ -168,6 +176,7 @@ export async function getEnvVarStatus(): Promise<EnvVarStatus[]> {
     { name: "NEXT_PUBLIC_SUPABASE_ANON_KEY", configured: !!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY, category: "required" },
     { name: "SUPABASE_SERVICE_ROLE_KEY", configured: !!process.env.SUPABASE_SERVICE_ROLE_KEY, category: "required" },
     { name: "NEXT_PUBLIC_GOOGLE_MAPS_API_KEY", configured: !!process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY, category: "maps" },
+    { name: "GOOGLE_MAPS_SERVER_API_KEY", configured: !!process.env.GOOGLE_MAPS_SERVER_API_KEY, category: "maps" },
     { name: "GOOGLE_MAPS_API_KEY", configured: !!process.env.GOOGLE_MAPS_API_KEY, category: "maps" },
     { name: "SMTP_HOST", configured: !!process.env.SMTP_HOST, category: "email" },
     { name: "SMTP_PORT", configured: !!process.env.SMTP_PORT, category: "email" },

--- a/src/lib/maps/__tests__/client.test.ts
+++ b/src/lib/maps/__tests__/client.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+const { mockFetch } = vi.hoisted(() => ({ mockFetch: vi.fn() }))
+
+vi.mock("server-only", () => ({}))
+vi.stubGlobal("fetch", mockFetch)
+
+import { callMapsApi } from "../client"
+import { MapsApiError } from "../errors"
+
+const URL = "https://maps.googleapis.com/maps/api/geocode/json"
+
+function okResponse(): void {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: () => Promise.resolve({ status: "OK" }),
+  })
+}
+
+/** Extract the `key` query param from the URL the fetch mock was called with. */
+function usedKey(): string | null {
+  const url = mockFetch.mock.calls[0]?.[0] as string
+  return new global.URL(url).searchParams.get("key")
+}
+
+describe("callMapsApi key selection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete process.env.GOOGLE_MAPS_SERVER_API_KEY
+    delete process.env.GOOGLE_MAPS_API_KEY
+  })
+
+  afterEach(() => {
+    // Don't leak env into other test files
+    delete process.env.GOOGLE_MAPS_SERVER_API_KEY
+    delete process.env.GOOGLE_MAPS_API_KEY
+    vi.restoreAllMocks()
+  })
+
+  it("uses GOOGLE_MAPS_SERVER_API_KEY when set", async () => {
+    okResponse()
+    process.env.GOOGLE_MAPS_SERVER_API_KEY = "server-key"
+
+    await callMapsApi(URL, { address: "x" })
+
+    expect(usedKey()).toBe("server-key")
+  })
+
+  it("prefers the server key over the legacy key when both are set", async () => {
+    okResponse()
+    process.env.GOOGLE_MAPS_SERVER_API_KEY = "server-key"
+    process.env.GOOGLE_MAPS_API_KEY = "legacy-key"
+
+    await callMapsApi(URL, { address: "x" })
+
+    expect(usedKey()).toBe("server-key")
+  })
+
+  it("falls back to GOOGLE_MAPS_API_KEY with a warning when server key is unset", async () => {
+    okResponse()
+    process.env.GOOGLE_MAPS_API_KEY = "legacy-key"
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    await callMapsApi(URL, { address: "x" })
+
+    expect(usedKey()).toBe("legacy-key")
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn.mock.calls[0]?.[0]).toContain("GOOGLE_MAPS_SERVER_API_KEY")
+  })
+
+  it("throws MapsApiError when neither key is configured", async () => {
+    okResponse()
+
+    await expect(callMapsApi(URL, { address: "x" })).rejects.toThrow(MapsApiError)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/maps/__tests__/directions.test.ts
+++ b/src/lib/maps/__tests__/directions.test.ts
@@ -61,7 +61,7 @@ function mockFetchResponse(body: unknown, ok = true, status = 200): void {
 describe("getRoute", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    process.env.GOOGLE_MAPS_API_KEY = "test-api-key"
+    process.env.GOOGLE_MAPS_SERVER_API_KEY = "test-api-key"
   })
 
   it("returns route result on success", async () => {
@@ -133,7 +133,8 @@ describe("getRoute", () => {
     await expect(getRoute(origin, destination)).rejects.toThrow(MapsApiError)
   })
 
-  it("throws MapsApiError when GOOGLE_MAPS_API_KEY is missing", async () => {
+  it("throws MapsApiError when no server key is set", async () => {
+    delete process.env.GOOGLE_MAPS_SERVER_API_KEY
     delete process.env.GOOGLE_MAPS_API_KEY
 
     await expect(getRoute(origin, destination)).rejects.toThrow(MapsApiError)

--- a/src/lib/maps/__tests__/geocode.test.ts
+++ b/src/lib/maps/__tests__/geocode.test.ts
@@ -74,7 +74,7 @@ function mockFetchResponse(body: unknown, ok = true, status = 200): void {
 describe("geocodeAddress", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    process.env.GOOGLE_MAPS_API_KEY = "test-api-key"
+    process.env.GOOGLE_MAPS_SERVER_API_KEY = "test-api-key"
   })
 
   it("returns geocode result on success", async () => {
@@ -137,7 +137,8 @@ describe("geocodeAddress", () => {
     await expect(geocodeAddress(testAddress)).rejects.toThrow(MapsApiError)
   })
 
-  it("throws MapsApiError when GOOGLE_MAPS_API_KEY is not set", async () => {
+  it("throws MapsApiError when no server key is set", async () => {
+    delete process.env.GOOGLE_MAPS_SERVER_API_KEY
     delete process.env.GOOGLE_MAPS_API_KEY
 
     await expect(geocodeAddress(testAddress)).rejects.toThrow(MapsApiError)
@@ -151,7 +152,7 @@ describe("geocodeAddress", () => {
 describe("geocodeAndUpdateRecord", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    process.env.GOOGLE_MAPS_API_KEY = "test-api-key"
+    process.env.GOOGLE_MAPS_SERVER_API_KEY = "test-api-key"
   })
 
   it("updates record with geocode result on success", async () => {

--- a/src/lib/maps/__tests__/places.test.ts
+++ b/src/lib/maps/__tests__/places.test.ts
@@ -55,7 +55,7 @@ function mockFetchResponse(body: unknown, ok = true): void {
 describe("getPlaceDetails", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    process.env.GOOGLE_MAPS_API_KEY = "test-api-key"
+    process.env.GOOGLE_MAPS_SERVER_API_KEY = "test-api-key"
   })
 
   it("returns place details on success", async () => {

--- a/src/lib/maps/client.ts
+++ b/src/lib/maps/client.ts
@@ -16,14 +16,42 @@ const NON_RETRYABLE_STATUSES = new Set([
   "NOT_FOUND",
 ])
 
+/**
+ * Returns the API key for Google Maps *Web Service* calls (Geocoding,
+ * Directions, Places Web Service).
+ *
+ * These are server-to-server requests that send no HTTP `Referer` header, so a
+ * referer-restricted key (as used by the browser Maps JS / Static Maps API)
+ * is rejected by Google with "API keys with referer restrictions cannot be
+ * used with this API". We therefore require a dedicated, non-referer-restricted
+ * server key:
+ *
+ *   1. GOOGLE_MAPS_SERVER_API_KEY  — preferred (unrestricted / IP-restricted)
+ *   2. GOOGLE_MAPS_API_KEY         — legacy fallback (deprecated), warns
+ *
+ * NEXT_PUBLIC_GOOGLE_MAPS_API_KEY must never be used here — it is the
+ * referer-restricted browser key.
+ */
 function getApiKey(): string {
-  const key = process.env.GOOGLE_MAPS_API_KEY
-  if (!key) {
-    throw new MapsApiError(
-      "GOOGLE_MAPS_API_KEY environment variable is not set"
-    )
+  const serverKey = process.env.GOOGLE_MAPS_SERVER_API_KEY
+  if (serverKey) {
+    return serverKey
   }
-  return key
+
+  const legacyKey = process.env.GOOGLE_MAPS_API_KEY
+  if (legacyKey) {
+    console.warn(
+      "[maps] GOOGLE_MAPS_SERVER_API_KEY is not set — falling back to the " +
+        "deprecated GOOGLE_MAPS_API_KEY. Configure an unrestricted server key " +
+        "to avoid referer-restriction errors on Geocoding/Directions/Places."
+    )
+    return legacyKey
+  }
+
+  throw new MapsApiError(
+    "No server Maps API key configured. Set GOOGLE_MAPS_SERVER_API_KEY " +
+      "(preferred) or GOOGLE_MAPS_API_KEY."
+  )
 }
 
 function isRetryableError(error: unknown): boolean {

--- a/supabase/migrations/20260714_000001_fix_geocode_status_none.sql
+++ b/supabase/migrations/20260714_000001_fix_geocode_status_none.sql
@@ -1,0 +1,70 @@
+-- KM-03: Fix invalid geocode_status in GDPR anonymization.
+--
+-- 20260321_000001_gdpr_anonymization.sql set geocode_status = 'none' in
+-- anonymize_patient(), but the CHECK constraint from
+-- 20260228_000001_geodata_fields.sql only permits
+-- ('pending', 'success', 'failed', 'manual'). Anonymizing a patient therefore
+-- raised a constraint-violation at runtime.
+--
+-- Fix: use 'pending'. Anonymized records have lat/lng = NULL, so 'pending' is
+-- the semantically correct state (no coordinates yet / to be re-evaluated) and
+-- keeps them out of the 'failed' bucket in the geocoding backfill.
+CREATE OR REPLACE FUNCTION anonymize_patient(p_patient_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    -- Check for active rides
+    IF EXISTS (
+        SELECT 1 FROM rides
+        WHERE patient_id = p_patient_id
+        AND status NOT IN ('completed', 'cancelled', 'no_show')
+        AND is_active = true
+    ) THEN
+        RAISE EXCEPTION 'Patient hat noch aktive Fahrten und kann nicht anonymisiert werden';
+    END IF;
+
+    -- Anonymize personal data
+    UPDATE patients SET
+        first_name = 'ANONYMISIERT',
+        last_name = 'ANONYMISIERT',
+        phone = NULL,
+        street = NULL,
+        house_number = NULL,
+        postal_code = LEFT(postal_code, 2) || '00',  -- Reduce to region for statistics
+        city = city,  -- Keep city for statistics
+        notes = NULL,
+        comment = NULL,
+        emergency_contact_name = NULL,
+        emergency_contact_phone = NULL,
+        formatted_address = NULL,
+        lat = NULL,
+        lng = NULL,
+        place_id = NULL,
+        geocode_status = 'pending',  -- was 'none' (invalid per CHECK constraint)
+        geocode_updated_at = NULL,
+        is_active = false,
+        updated_at = NOW()
+    WHERE id = p_patient_id;
+
+    -- Remove impairments (personal health data)
+    DELETE FROM patient_impairments WHERE patient_id = p_patient_id;
+
+    -- Deactivate associated ride series
+    UPDATE ride_series SET
+        is_active = false,
+        notes = NULL,
+        updated_at = NOW()
+    WHERE patient_id = p_patient_id;
+
+    -- Anonymize communication log entries
+    UPDATE communication_log SET
+        message = '[Anonymisiert gemaess DSGVO Art. 17]'
+    WHERE ride_id IN (SELECT id FROM rides WHERE patient_id = p_patient_id);
+END;
+$$;
+
+-- Preserve the least-privilege grant from the original migration.
+REVOKE ALL ON FUNCTION anonymize_patient(UUID) FROM PUBLIC;


### PR DESCRIPTION
Erste zwei Issues des Milestones **Karten fixen** (#7). Behebt den akut gemeldeten Geocoding-Fehler *„API keys with referer restrictions cannot be used with this API"*.

## KM-01 — Server-Key-Trennung (#108)
- `lib/maps/client.ts` `getApiKey()`: bevorzugt `GOOGLE_MAPS_SERVER_API_KEY`, Fallback auf `GOOGLE_MAPS_API_KEY` (deprecated, mit `console.warn`), sonst `MapsApiError`. Fixt Geocoding + Directions + Places (alle via `callMapsApi`).
- `actions/system.ts`: Health-Check + Env-Var-Liste auf Server-Key umgestellt.
- `.env.example` / `.env.local.example`: Key-Konvention dokumentiert (Server = unrestricted Webservice, `NEXT_PUBLIC` = referer-restricted Browser).
- Tests: bestehende geocode/directions/places-Tests stubben nun `GOOGLE_MAPS_SERVER_API_KEY`; neues `client.test.ts` deckt Precedence/Fallback/Fehlerfall ab.

## KM-03 — geocode_status-Constraint-Fix (#109)
- Neue Migration `20260714_000001_fix_geocode_status_none.sql`: `anonymize_patient()` setzte `geocode_status='none'` (verletzt CHECK-Constraint → Laufzeitfehler bei jeder Anonymisierung) → jetzt `'pending'`.

## ⚠️ Erforderliche Nutzer-Aktion (Google Cloud) — sonst wirkt KM-01 nicht
- Server-Key erstellen: **Application restriction = None** (Vercel-IPs dynamisch), **API restriction = Geocoding + Directions + Places**.
- Als `GOOGLE_MAPS_SERVER_API_KEY` in **Vercel** (Prod+Preview) und `.env.local` setzen.
- `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` bleibt referer-restringiert. **Budget-Alert** setzen.

## Verifikation
- Typecheck ✅ · Lint ✅ · Tests ✅ (33 Dateien, 609 Tests, inkl. 4 neue in `client.test.ts`)

Closes #108
Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)