### PR TITLE
feat(maps): Chunked Geocoding-Backfill (KM-04, KM-05)

### DIFF
--- a/src/actions/geocoding.ts
+++ b/src/actions/geocoding.ts
@@ -2,23 +2,9 @@
 
 import { createClient } from "@/lib/supabase/server"
 import { requireAuth } from "@/lib/auth/require-auth"
-import { geocodeAddress } from "@/lib/maps/geocode"
-import type { AddressInput } from "@/lib/maps/types"
+import { processGeocodingBatch } from "@/lib/maps/geocode-batch"
+import type { BatchGeocodeResult } from "@/lib/maps/geocode-batch"
 import type { ActionResult } from "@/actions/shared"
-
-interface RetryError {
-  id: string
-  address: string
-  error: string
-}
-
-interface RetryResult {
-  patients_processed: number
-  patients_success: number
-  destinations_processed: number
-  destinations_success: number
-  errors: RetryError[]
-}
 
 export async function getMapsHealthStats(): Promise<ActionResult<{
   patients: { total: number; geocoded: number; failed: number; pending: number }
@@ -66,175 +52,38 @@ export async function getMapsHealthStats(): Promise<ActionResult<{
   }
 }
 
+/** Upper bound on records processed per request, keeping each call well under
+ *  the serverless time budget. The backfill UI calls this repeatedly. */
+const MAX_BATCH_LIMIT = 100
+
 /**
- * Re-geocodes all patients and destinations
- with failed, pending, or null
- * geocode_status that have complete address data.
+ * Processes one chunk of the geocoding backfill (patients + destinations with
+ * pending/failed/null status and a complete address). Designed to be called
+ * repeatedly by the client, passing back the returned `cursor` each time, until
+ * `remaining` reaches 0.
  *
- * Uses a single Supabase client for efficiency instead of calling
- * geocodeAndUpdateRecord (which creates its own client per call).
+ * Preferred over a single full-table pass, which times out on ~1200 records.
  */
-export async function retryFailedGeocoding(): Promise<
-  ActionResult<RetryResult>
-> {
+export async function geocodeBatch(
+  limit = 50,
+  cursor?: string
+): Promise<ActionResult<BatchGeocodeResult>> {
   const auth = await requireAuth(["admin", "operator"])
   if (!auth.authorized) {
     return { success: false, error: "Nicht berechtigt" }
   }
 
+  const safeLimit = Math.min(Math.max(1, Math.floor(limit)), MAX_BATCH_LIMIT)
   const supabase = await createClient()
-  let patientsProcessed = 0
-  let patientsSuccess = 0
-  let destinationsProcessed = 0
-  let destinationsSuccess = 0
-  const errors: RetryError[] = []
 
-  // Fetch patients with failed/pending/null geocode_status and complete addresses
-  const { data: patients, error: patientsError } = await supabase
-    .from("patients")
-    .select("id, street, house_number, postal_code, city")
-    .or("geocode_status.eq.failed,geocode_status.eq.pending,geocode_status.is.null")
-    .not("street", "is", null)
-    .not("house_number", "is", null)
-    .not("postal_code", "is", null)
-    .not("city", "is", null)
-
-  if (patientsError) {
-    console.error("Failed to fetch patients for re-geocoding:", patientsError.message)
-    return { success: false, error: "Patienten konnten nicht geladen werden" }
-  }
-
-  for (const patient of patients) {
-    patientsProcessed++
-    const address: AddressInput = {
-      street: patient.street!,
-      house_number: patient.house_number!,
-      postal_code: patient.postal_code!,
-      city: patient.city!,
+  try {
+    const data = await processGeocodingBatch(supabase, safeLimit, cursor)
+    return { success: true, data }
+  } catch (err) {
+    console.error("geocodeBatch failed:", err)
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : "Geocoding fehlgeschlagen",
     }
-    const addressStr = `${address.street} ${address.house_number}, ${address.postal_code} ${address.city}`
-    const now = new Date().toISOString()
-
-    try {
-      const result = await geocodeAddress(address)
-
-      if (result) {
-        const { error } = await supabase
-          .from("patients")
-          .update({
-            lat: result.lat,
-            lng: result.lng,
-            place_id: result.place_id,
-            formatted_address: result.formatted_address,
-            geocode_status: "success",
-            geocode_updated_at: now,
-          })
-          .eq("id", patient.id)
-
-        if (error) {
-          errors.push({ id: patient.id, address: addressStr, error: `DB-Update: ${error.message}` })
-        } else {
-          patientsSuccess++
-        }
-      } else {
-        // ZERO_RESULTS
-        await supabase
-          .from("patients")
-          .update({ geocode_status: "failed", geocode_updated_at: now })
-          .eq("id", patient.id)
-        errors.push({ id: patient.id, address: addressStr, error: "Adresse nicht gefunden (ZERO_RESULTS)" })
-      }
-    } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err)
-      errors.push({ id: patient.id, address: addressStr, error: errMsg })
-      try {
-        await supabase
-          .from("patients")
-          .update({ geocode_status: "failed", geocode_updated_at: now })
-          .eq("id", patient.id)
-      } catch {
-        // ignore
-      }
-    }
-  }
-
-  // Fetch destinations with failed/pending/null geocode_status and complete addresses
-  const { data: destinations, error: destinationsError } = await supabase
-    .from("destinations")
-    .select("id, street, house_number, postal_code, city")
-    .or("geocode_status.eq.failed,geocode_status.eq.pending,geocode_status.is.null")
-    .not("street", "is", null)
-    .not("house_number", "is", null)
-    .not("postal_code", "is", null)
-    .not("city", "is", null)
-
-  if (destinationsError) {
-    console.error("Failed to fetch destinations for re-geocoding:", destinationsError.message)
-    return { success: false, error: "Ziele konnten nicht geladen werden" }
-  }
-
-  for (const destination of destinations) {
-    destinationsProcessed++
-    const address: AddressInput = {
-      street: destination.street!,
-      house_number: destination.house_number!,
-      postal_code: destination.postal_code!,
-      city: destination.city!,
-    }
-    const addressStr = `${address.street} ${address.house_number}, ${address.postal_code} ${address.city}`
-    const now = new Date().toISOString()
-
-    try {
-      const result = await geocodeAddress(address)
-
-      if (result) {
-        const { error } = await supabase
-          .from("destinations")
-          .update({
-            lat: result.lat,
-            lng: result.lng,
-            place_id: result.place_id,
-            formatted_address: result.formatted_address,
-            geocode_status: "success",
-            geocode_updated_at: now,
-          })
-          .eq("id", destination.id)
-
-        if (error) {
-          errors.push({ id: destination.id, address: addressStr, error: `DB-Update: ${error.message}` })
-        } else {
-          destinationsSuccess++
-        }
-      } else {
-        // ZERO_RESULTS
-        await supabase
-          .from("destinations")
-          .update({ geocode_status: "failed", geocode_updated_at: now })
-          .eq("id", destination.id)
-        errors.push({ id: destination.id, address: addressStr, error: "Adresse nicht gefunden (ZERO_RESULTS)" })
-      }
-    } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err)
-      errors.push({ id: destination.id, address: addressStr, error: errMsg })
-      try {
-        await supabase
-          .from("destinations")
-          .update({ geocode_status: "failed", geocode_updated_at: now })
-          .eq("id", destination.id)
-      } catch {
-        // ignore
-      }
-    }
-  }
-
-  return {
-    success: true,
-    data: {
-      patients_processed: patientsProcessed,
-      patients_success: patientsSuccess,
-      destinations_processed: destinationsProcessed,
-      destinations_success: destinationsSuccess,
-      errors,
-    },
   }
 }

--- a/src/components/settings/retry-geocoding-card.tsx
+++ b/src/components/settings/retry-geocoding-card.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { useTransition, useState } from "react"
+import { useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
+import { Progress } from "@/components/ui/progress"
 import {
   Card,
   CardContent,
@@ -9,97 +10,158 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import { retryFailedGeocoding } from "@/actions/geocoding"
+import { geocodeBatch } from "@/actions/geocoding"
+import type { GeocodeBatchError } from "@/lib/maps/geocode-batch"
 
-interface RetryError {
-  id: string
-  address: string
-  error: string
+const BATCH_SIZE = 50
+const MAX_SHOWN_ERRORS = 200
+
+type Phase = "idle" | "running" | "done" | "error"
+
+interface Progressish {
+  processed: number
+  succeeded: number
+  failed: number
+  remaining: number
+  total: number
 }
 
-interface RetryResult {
-  patients_processed: number
-  patients_success: number
-  destinations_processed: number
-  destinations_success: number
-  errors: RetryError[]
-}
-
-type ResultState =
-  | { type: "idle" }
-  | { type: "success"; data: RetryResult }
-  | { type: "error"; message: string }
+const ZERO: Progressish = { processed: 0, succeeded: 0, failed: 0, remaining: 0, total: 0 }
 
 export function RetryGeocodingCard() {
-  const [isPending, startTransition] = useTransition()
-  const [result, setResult] = useState<ResultState>({ type: "idle" })
+  const [phase, setPhase] = useState<Phase>("idle")
+  const [stats, setStats] = useState<Progressish>(ZERO)
+  const [errors, setErrors] = useState<GeocodeBatchError[]>([])
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  const cancelRef = useRef(false)
 
-  function handleRetry() {
-    setResult({ type: "idle" })
-    startTransition(async () => {
-      const response = await retryFailedGeocoding()
-      if (response.success) {
-        setResult({ type: "success", data: response.data })
-      } else {
-        setResult({
-          type: "error",
-          message: response.error ?? "Unbekannter Fehler",
-        })
+  async function runBackfill() {
+    cancelRef.current = false
+    setPhase("running")
+    setStats(ZERO)
+    setErrors([])
+    setErrorMsg(null)
+
+    let cursor: string | undefined
+    let processed = 0
+    let succeeded = 0
+    let failed = 0
+    let total = 0
+    const collected: GeocodeBatchError[] = []
+
+    for (;;) {
+      if (cancelRef.current) {
+        setPhase("done")
+        return
       }
-    })
+
+      const res = await geocodeBatch(BATCH_SIZE, cursor)
+      if (!res.success) {
+        setErrorMsg(res.error ?? "Unbekannter Fehler")
+        setPhase("error")
+        return
+      }
+
+      const d = res.data
+      cursor = d.cursor
+      processed += d.processed
+      succeeded += d.succeeded
+      failed += d.failed
+      total = Math.max(total, processed + d.remaining)
+      for (const e of d.errors) {
+        if (collected.length < MAX_SHOWN_ERRORS) collected.push(e)
+      }
+
+      setStats({ processed, succeeded, failed, remaining: d.remaining, total })
+      setErrors([...collected])
+
+      // remaining === 0 -> complete; processed === 0 -> nothing left to attempt
+      if (d.remaining === 0 || d.processed === 0) {
+        setPhase("done")
+        return
+      }
+    }
   }
+
+  const percent = stats.total > 0 ? Math.round((stats.processed / stats.total) * 100) : 0
+  const isRunning = phase === "running"
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Geocoding</CardTitle>
+        <CardTitle>Geocoding-Backfill</CardTitle>
         <CardDescription>
-          Adressen ohne Koordinaten erneut geocoden
+          Adressen ohne Koordinaten in Blöcken geocoden (Patienten &amp; Ziele).
+          Erneut ausführbar; bereits geocodete Adressen werden übersprungen.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <Button onClick={handleRetry} disabled={isPending}>
-          {isPending
-            ? "Geocoding laeuft..."
-            : "Fehlgeschlagene Adressen erneut geocoden"}
-        </Button>
+        <div className="flex gap-3">
+          <Button onClick={runBackfill} disabled={isRunning}>
+            {isRunning ? "Läuft…" : "Backfill starten"}
+          </Button>
+          {isRunning && (
+            <Button
+              variant="outline"
+              onClick={() => {
+                cancelRef.current = true
+              }}
+            >
+              Abbrechen
+            </Button>
+          )}
+        </div>
 
-        {result.type === "success" && (
-          <div className="rounded-md border border-green-200 bg-green-50 px-4 py-3 text-sm dark:border-green-800 dark:bg-green-950">
-            <p className="font-medium text-green-800 dark:text-green-200">
-              Geocoding abgeschlossen
-            </p>
-            <p className="mt-1 text-green-700 dark:text-green-300">
-              Patienten: {result.data.patients_success}/
-              {result.data.patients_processed} erfolgreich
-            </p>
-            <p className="text-green-700 dark:text-green-300">
-              Ziele: {result.data.destinations_success}/
-              {result.data.destinations_processed} erfolgreich
-            </p>
-            {result.data.errors.length > 0 && (
-              <div className="mt-3 space-y-1 border-t border-green-200 pt-3 dark:border-green-800">
-                <p className="font-medium text-amber-800 dark:text-amber-200">
-                  Fehler ({result.data.errors.length}):
-                </p>
-                {result.data.errors.map((err, i) => (
-                  <p key={i} className="text-xs text-amber-700 dark:text-amber-300">
-                    {err.address} — {err.error}
-                  </p>
-                ))}
-              </div>
-            )}
+        {(isRunning || phase === "done") && stats.total > 0 && (
+          <div className="space-y-2">
+            <Progress value={percent} />
+            <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+              <span>{stats.processed}/{stats.total} verarbeitet ({percent}%)</span>
+              <span className="text-green-700 dark:text-green-400">
+                {stats.succeeded} erfolgreich
+              </span>
+              {stats.failed > 0 && (
+                <span className="text-amber-700 dark:text-amber-400">
+                  {stats.failed} fehlgeschlagen
+                </span>
+              )}
+              <span>{stats.remaining} verbleibend</span>
+            </div>
           </div>
         )}
 
-        {result.type === "error" && (
+        {phase === "done" && (
+          <div className="rounded-md border border-green-200 bg-green-50 px-4 py-3 text-sm dark:border-green-800 dark:bg-green-950">
+            <p className="font-medium text-green-800 dark:text-green-200">
+              {cancelRef.current ? "Backfill abgebrochen" : "Backfill abgeschlossen"}
+            </p>
+            <p className="mt-1 text-green-700 dark:text-green-300">
+              {stats.succeeded} erfolgreich, {stats.failed} fehlgeschlagen von{" "}
+              {stats.processed} verarbeitet.
+            </p>
+          </div>
+        )}
+
+        {phase === "error" && (
           <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm dark:border-red-800 dark:bg-red-950">
-            <p className="font-medium text-red-800 dark:text-red-200">
-              Fehler
+            <p className="font-medium text-red-800 dark:text-red-200">Fehler</p>
+            <p className="mt-1 text-red-700 dark:text-red-300">{errorMsg}</p>
+          </div>
+        )}
+
+        {errors.length > 0 && (
+          <div className="space-y-1 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-800 dark:bg-amber-950">
+            <p className="font-medium text-amber-800 dark:text-amber-200">
+              Nicht geocodierbar ({errors.length}
+              {errors.length >= MAX_SHOWN_ERRORS ? "+" : ""}):
             </p>
-            <p className="mt-1 text-red-700 dark:text-red-300">
-              {result.message}
-            </p>
+            <div className="max-h-48 space-y-0.5 overflow-y-auto">
+              {errors.map((err, i) => (
+                <p key={`${err.table}-${err.id}-${i}`} className="text-xs text-amber-700 dark:text-amber-300">
+                  {err.address} — {err.error}
+                </p>
+              ))}
+            </div>
           </div>
         )}
       </CardContent>

--- a/src/lib/maps/__tests__/geocode-batch.test.ts
+++ b/src/lib/maps/__tests__/geocode-batch.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const { mockGeocode } = vi.hoisted(() => ({ mockGeocode: vi.fn() }))
+
+vi.mock("server-only", () => ({}))
+vi.mock("../geocode", () => ({ geocodeAddress: mockGeocode }))
+
+import { processGeocodingBatch } from "../geocode-batch"
+
+interface Row {
+  id: string
+  street: string
+  house_number: string
+  postal_code: string
+  city: string
+}
+
+function row(id: string): Row {
+  return { id, street: "Teststr", house_number: id, postal_code: "8600", city: "Duebendorf" }
+}
+
+/**
+ * Minimal fake of the Supabase query builder covering exactly the shapes
+ * processGeocodingBatch uses: select-with-filters (data), count head queries,
+ * and update().eq(). Records updates + `.or()` filter args for assertions.
+ */
+function createFake(config: {
+  patients: Row[]
+  destinations: Row[]
+  remaining: { patients: number; destinations: number }
+}) {
+  const updates: Array<{ table: string; payload: Record<string, unknown> }> = []
+  const orFilters: string[] = []
+
+  function builder(table: string) {
+    const b: Record<string, unknown> = {}
+    let isCount = false
+    let updatePayload: Record<string, unknown> | null = null
+
+    Object.assign(b, {
+      select: (_cols: string, opts?: { head?: boolean }) => {
+        if (opts?.head) isCount = true
+        return b
+      },
+      or: (expr: string) => {
+        orFilters.push(expr)
+        return b
+      },
+      not: () => b,
+      order: () => b,
+      limit: () => b,
+      eq: () => b,
+      update: (payload: Record<string, unknown>) => {
+        updatePayload = payload
+        return b
+      },
+      then: (resolve: (v: unknown) => unknown) => {
+        if (updatePayload) {
+          updates.push({ table, payload: updatePayload })
+          return resolve({ error: null })
+        }
+        if (isCount) {
+          return resolve({ count: (config.remaining as Record<string, number>)[table] ?? 0 })
+        }
+        const rows = table === "patients" ? config.patients : config.destinations
+        return resolve({ data: rows, error: null })
+      },
+    })
+    return b
+  }
+
+  return { client: { from: (t: string) => builder(t) } as never, updates, orFilters }
+}
+
+const okResult = {
+  lat: 47.4,
+  lng: 8.6,
+  place_id: "pid",
+  formatted_address: "Teststr 1, 8600 Duebendorf",
+}
+
+describe("processGeocodingBatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("geocodes patients and destinations and marks them success", async () => {
+    mockGeocode.mockResolvedValue(okResult)
+    const fake = createFake({
+      patients: [row("1"), row("2")],
+      destinations: [row("3")],
+      remaining: { patients: 0, destinations: 0 },
+    })
+
+    const res = await processGeocodingBatch(fake.client, 50)
+
+    expect(res.processed).toBe(3)
+    expect(res.succeeded).toBe(3)
+    expect(res.failed).toBe(0)
+    expect(res.remaining).toBe(0)
+    expect(res.cursor).toBeTypeOf("string")
+    // Every record got a success update
+    expect(fake.updates).toHaveLength(3)
+    expect(fake.updates.every((u) => u.payload.geocode_status === "success")).toBe(true)
+  })
+
+  it("marks ZERO_RESULTS as failed and collects the error", async () => {
+    mockGeocode.mockResolvedValue(null) // ZERO_RESULTS
+    const fake = createFake({
+      patients: [row("1")],
+      destinations: [],
+      remaining: { patients: 1, destinations: 0 },
+    })
+
+    const res = await processGeocodingBatch(fake.client, 50)
+
+    expect(res.succeeded).toBe(0)
+    expect(res.failed).toBe(1)
+    expect(res.errors[0]?.error).toContain("ZERO_RESULTS")
+    expect(fake.updates[0]?.payload.geocode_status).toBe("failed")
+  })
+
+  it("marks a thrown geocode error as failed", async () => {
+    mockGeocode.mockRejectedValue(new Error("REQUEST_DENIED"))
+    const fake = createFake({
+      patients: [row("1")],
+      destinations: [],
+      remaining: { patients: 0, destinations: 0 },
+    })
+
+    const res = await processGeocodingBatch(fake.client, 50)
+
+    expect(res.failed).toBe(1)
+    expect(res.errors[0]?.error).toContain("REQUEST_DENIED")
+    expect(fake.updates[0]?.payload.geocode_status).toBe("failed")
+  })
+
+  it("reports remaining from the count queries and reuses a provided cursor", async () => {
+    mockGeocode.mockResolvedValue(okResult)
+    const fake = createFake({
+      patients: [row("1")],
+      destinations: [],
+      remaining: { patients: 40, destinations: 60 },
+    })
+
+    const res = await processGeocodingBatch(fake.client, 50, "2026-07-14T10:00:00.000Z")
+
+    expect(res.remaining).toBe(100)
+    expect(res.cursor).toBe("2026-07-14T10:00:00.000Z")
+    // The cursor is applied as a geocode_updated_at filter on fetch + count.
+    expect(
+      fake.orFilters.some((f) => f.includes("geocode_updated_at.lt.2026-07-14T10:00:00.000Z"))
+    ).toBe(true)
+    // Only pending/failed/null are targeted (success/manual excluded).
+    expect(fake.orFilters.some((f) => f.includes("geocode_status.eq.pending"))).toBe(true)
+  })
+
+  it("does not fetch destinations when patients already fill the limit", async () => {
+    mockGeocode.mockResolvedValue(okResult)
+    const fake = createFake({
+      patients: [row("1"), row("2")],
+      destinations: [row("99")],
+      remaining: { patients: 5, destinations: 5 },
+    })
+
+    // limit 2 is filled by the 2 patients -> destinations fetch is skipped
+    const res = await processGeocodingBatch(fake.client, 2)
+
+    expect(res.processed).toBe(2)
+    expect(fake.updates.every((u) => u.table === "patients")).toBe(true)
+  })
+})

--- a/src/lib/maps/geocode-batch.ts
+++ b/src/lib/maps/geocode-batch.ts
@@ -1,0 +1,234 @@
+import "server-only"
+
+import type { SupabaseClient } from "@supabase/supabase-js"
+import type { Database } from "@/lib/types/database"
+import { geocodeAddress } from "./geocode"
+import type { AddressInput } from "./types"
+
+type GeocodableTable = "patients" | "destinations"
+
+/** Records processed concurrently per chunk (Google Geocoding QPS is generous;
+ *  the real constraint is the serverless time budget per HTTP call). */
+const CONCURRENCY = 5
+
+/** Status values that still need a geocoding attempt (success/manual excluded). */
+const OPEN_STATUS_FILTER =
+  "geocode_status.eq.failed,geocode_status.eq.pending,geocode_status.is.null"
+
+export interface GeocodeBatchError {
+  id: string
+  table: GeocodableTable
+  address: string
+  error: string
+}
+
+export interface BatchGeocodeResult {
+  processed: number
+  succeeded: number
+  failed: number
+  /** Open, geocodable records left AFTER this batch (excludes ones attempted
+   *  this session via the cursor). Reaches 0 when the backfill is complete. */
+  remaining: number
+  /** Server-authoritative session cursor. Pass it back on the next call so
+   *  records attempted this session are not re-selected (guarantees the
+   *  driving loop terminates and each record is attempted at most once). */
+  cursor: string
+  errors: GeocodeBatchError[]
+}
+
+interface OpenRecord {
+  id: string
+  street: string | null
+  house_number: string | null
+  postal_code: string | null
+  city: string | null
+}
+
+type Client = SupabaseClient<Database>
+
+function addressOf(r: OpenRecord): AddressInput {
+  return {
+    street: r.street!,
+    house_number: r.house_number!,
+    postal_code: r.postal_code!,
+    city: r.city!,
+  }
+}
+
+function addressLabel(a: AddressInput): string {
+  return `${a.street} ${a.house_number}, ${a.postal_code} ${a.city}`
+}
+
+/** Fetch up to `limit` open, fully-addressed records not yet attempted this
+ *  session (geocode_updated_at is null or older than the cursor). */
+async function fetchOpen(
+  supabase: Client,
+  table: GeocodableTable,
+  limit: number,
+  cursor: string
+): Promise<OpenRecord[]> {
+  const { data, error } = await supabase
+    .from(table)
+    .select("id, street, house_number, postal_code, city")
+    .or(OPEN_STATUS_FILTER)
+    .or(`geocode_updated_at.is.null,geocode_updated_at.lt.${cursor}`)
+    .not("street", "is", null)
+    .not("house_number", "is", null)
+    .not("postal_code", "is", null)
+    .not("city", "is", null)
+    .order("geocode_updated_at", { ascending: true, nullsFirst: true })
+    .limit(limit)
+
+  if (error) {
+    throw new Error(`Konnte ${table} nicht laden: ${error.message}`)
+  }
+  return (data ?? []) as OpenRecord[]
+}
+
+/** Count open, fully-addressed records not yet attempted this session. */
+async function countOpen(
+  supabase: Client,
+  table: GeocodableTable,
+  cursor: string
+): Promise<number> {
+  const { count } = await supabase
+    .from(table)
+    .select("id", { count: "exact", head: true })
+    .or(OPEN_STATUS_FILTER)
+    .or(`geocode_updated_at.is.null,geocode_updated_at.lt.${cursor}`)
+    .not("street", "is", null)
+    .not("house_number", "is", null)
+    .not("postal_code", "is", null)
+    .not("city", "is", null)
+  return count ?? 0
+}
+
+/**
+ * Geocode one record and persist the outcome. Always stamps geocode_updated_at
+ * (>= cursor) so the record drops out of this session's open set — whether it
+ * succeeded or failed. Returns an error descriptor on failure, else null.
+ */
+async function processRecord(
+  supabase: Client,
+  table: GeocodableTable,
+  record: OpenRecord
+): Promise<GeocodeBatchError | null> {
+  const address = addressOf(record)
+  const label = addressLabel(address)
+  const now = new Date().toISOString()
+
+  try {
+    const result = await geocodeAddress(address)
+
+    if (result) {
+      const { error } = await supabase
+        .from(table)
+        .update({
+          lat: result.lat,
+          lng: result.lng,
+          place_id: result.place_id,
+          formatted_address: result.formatted_address,
+          geocode_status: "success",
+          geocode_updated_at: now,
+        })
+        .eq("id", record.id)
+      if (error) {
+        return { id: record.id, table, address: label, error: `DB-Update: ${error.message}` }
+      }
+      return null
+    }
+
+    // ZERO_RESULTS
+    await supabase
+      .from(table)
+      .update({ geocode_status: "failed", geocode_updated_at: now })
+      .eq("id", record.id)
+    return { id: record.id, table, address: label, error: "Adresse nicht gefunden (ZERO_RESULTS)" }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    // Best-effort: mark failed + stamp so it leaves this session's open set.
+    try {
+      await supabase
+        .from(table)
+        .update({ geocode_status: "failed", geocode_updated_at: now })
+        .eq("id", record.id)
+    } catch {
+      // ignore secondary failure
+    }
+    return { id: record.id, table, address: label, error: message }
+  }
+}
+
+/** Run tasks with bounded concurrency, collecting all results. */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  worker: (item: T) => Promise<R>,
+  concurrency: number
+): Promise<R[]> {
+  const results: R[] = []
+  for (let i = 0; i < items.length; i += concurrency) {
+    const chunk = items.slice(i, i + concurrency)
+    const settled = await Promise.allSettled(chunk.map(worker))
+    for (const s of settled) {
+      if (s.status === "fulfilled") {
+        results.push(s.value)
+      }
+    }
+  }
+  return results
+}
+
+/**
+ * Idempotent, chunked geocoding backfill over patients + destinations.
+ *
+ * Processes up to `limit` open records per call (patients first, then
+ * destinations to fill the quota), at concurrency 5. Only records that still
+ * need geocoding are touched (pending/failed/null status, complete address);
+ * `success` and `manual` records are never re-geocoded, so manually corrected
+ * coordinates are preserved.
+ *
+ * The session `cursor` (server-generated on the first call, echoed back by the
+ * caller afterwards) ensures each record is attempted at most once per backfill
+ * run and that the driving loop terminates even for permanently failing
+ * addresses.
+ */
+export async function processGeocodingBatch(
+  supabase: Client,
+  limit = 50,
+  cursor?: string
+): Promise<BatchGeocodeResult> {
+  const sessionCursor = cursor ?? new Date().toISOString()
+
+  const patients = await fetchOpen(supabase, "patients", limit, sessionCursor)
+  const destinations =
+    patients.length < limit
+      ? await fetchOpen(supabase, "destinations", limit - patients.length, sessionCursor)
+      : []
+
+  const tasks: Array<{ table: GeocodableTable; record: OpenRecord }> = [
+    ...patients.map((record) => ({ table: "patients" as const, record })),
+    ...destinations.map((record) => ({ table: "destinations" as const, record })),
+  ]
+
+  const errors = (
+    await mapWithConcurrency(
+      tasks,
+      ({ table, record }) => processRecord(supabase, table, record),
+      CONCURRENCY
+    )
+  ).filter((e): e is GeocodeBatchError => e !== null)
+
+  const [remPatients, remDestinations] = await Promise.all([
+    countOpen(supabase, "patients", sessionCursor),
+    countOpen(supabase, "destinations", sessionCursor),
+  ])
+
+  return {
+    processed: tasks.length,
+    succeeded: tasks.length - errors.length,
+    failed: errors.length,
+    remaining: remPatients + remDestinations,
+    cursor: sessionCursor,
+    errors,
+  }
+}


### PR DESCRIPTION
Schritt 1 des Milestones **Karten fixen** (#7): der Backfill der ~1200 Patienten/Ziele läuft jetzt gechunkt statt in einem Request (der bei 1200 Records den Serverless-Timeout riss).

## KM-04 — `processGeocodingBatch` (#110)
- Neue Kernfunktion `src/lib/maps/geocode-batch.ts`: verarbeitet pro Aufruf bis zu `limit` offene Records (Patienten, dann Ziele), **Parallelität 5** via `Promise.allSettled`.
- **Idempotent:** nur `pending`/`failed`/`null` mit vollständiger Adresse; `success`/`manual` werden nie angefasst → manuell gesetzte Koordinaten bleiben erhalten.
- **Terminierend:** server-autoritativer Session-`cursor` (`geocode_updated_at`) — jeder Record wird pro Lauf höchstens einmal versucht, auch dauerhaft fehlschlagende Adressen brechen die Schleife nicht.
- Neue Server-Action `geocodeBatch(limit, cursor)`; `retryFailedGeocoding` (Single-Pass) entfernt. Unit-Tests für Erfolg/ZERO_RESULTS/Fehler/remaining/Limit.

## KM-05 — Backfill-UI (#111)
- `RetryGeocodingCard` ruft `geocodeBatch` in einer Schleife (50/Aufruf) bis `remaining=0`: Fortschrittsbalken, Live-Zähler (verarbeitet/erfolgreich/fehlgeschlagen/verbleibend), Abbrechen-Button, scrollbare Fehlerliste. Fortsetzbar.

## Nächste Schritte im Milestone
- **KM-06** Cron-Safety-Net (die Kernfunktion nimmt bereits einen injizierten Client — Admin-Client für Cron).
- **KM-08** eigentlicher Backfill-Lauf über die ~1200 Records (Betrieb, nach diesem Merge).

## Verifikation
- Typecheck ✅ · Lint ✅ · **748 Tests** ✅ (5 neue) · `next build` ✅ (Server/Client-Grenze ok trotz Type-Import aus server-only-Modul in Client-Komponente)

Closes #110
Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)