### PR TITLE
feat(maps): Cron-Safety-Net + Change-Detection (KM-06, KM-07)

### DIFF
--- a/src/actions/destinations.ts
+++ b/src/actions/destinations.ts
@@ -64,11 +64,11 @@ export async function createDestination(
     return { success: false, error: error.message }
   }
 
-  // Fire-and-forget geocoding only when no coordinates came from Places
+  // Fire-and-forget geocoding only when no coordinates came from Places.
+  // House number is optional (KM-14) — facility addresses often have none.
   if (
     !hasGeoData &&
     destinationData.street &&
-    destinationData.house_number &&
     destinationData.postal_code &&
     destinationData.city
   ) {
@@ -130,9 +130,31 @@ export async function updateDestination(
     : destinationData
 
   const supabase = await createClient()
+
+  // KM-07: fetch current address + status to decide whether to re-geocode.
+  const { data: existing } = await supabase
+    .from("destinations")
+    .select("street, house_number, postal_code, city, geocode_status")
+    .eq("id", id)
+    .single()
+
+  const addressChanged =
+    !existing ||
+    existing.street !== destinationData.street ||
+    existing.house_number !== destinationData.house_number ||
+    existing.postal_code !== destinationData.postal_code ||
+    existing.city !== destinationData.city
+
+  // Mark pending when the address changed and no Places coords were supplied,
+  // so the backfill/cron recovers if the fire-and-forget geocode below fails.
+  const finalUpdate =
+    !hasGeoData && addressChanged
+      ? { ...updateData, geocode_status: "pending" as const }
+      : updateData
+
   const { error } = await supabase
     .from("destinations")
-    .update(updateData)
+    .update(finalUpdate)
     .eq("id", id)
     .select()
     .single()
@@ -141,11 +163,13 @@ export async function updateDestination(
     return { success: false, error: error.message }
   }
 
-  // Fire-and-forget geocoding only when no coordinates came from Places
+  // Fire-and-forget geocoding — only when no Places coords, and the address
+  // changed or was never geocoded (KM-07). House number optional (KM-14).
+  const needsGeocode = addressChanged || existing?.geocode_status !== "success"
   if (
     !hasGeoData &&
+    needsGeocode &&
     destinationData.street &&
-    destinationData.house_number &&
     destinationData.postal_code &&
     destinationData.city
   ) {

--- a/src/actions/patients.ts
+++ b/src/actions/patients.ts
@@ -68,8 +68,9 @@ export async function createPatient(
     entityId: patient.id,
   }).catch(() => {})
 
-  // Fire-and-forget geocoding (don't block the response)
-  if (patientData.street && patientData.house_number && patientData.postal_code && patientData.city) {
+  // Fire-and-forget geocoding (don't block the response). House number is
+  // optional (KM-14) — facility addresses often have none.
+  if (patientData.street && patientData.postal_code && patientData.city) {
     geocodeAndUpdateRecord("patients", patient.id, {
       street: patientData.street,
       house_number: patientData.house_number,
@@ -108,9 +109,29 @@ export async function updatePatient(
   const { impairments: validatedImpairments, ...patientData } = result.data
 
   const supabase = await createClient()
+
+  // KM-07: only re-geocode when the address actually changed (or was never
+  // successfully geocoded). Fetch the current address + status first.
+  const { data: existing } = await supabase
+    .from("patients")
+    .select("street, house_number, postal_code, city, geocode_status")
+    .eq("id", id)
+    .single()
+
+  const addressChanged =
+    !existing ||
+    existing.street !== patientData.street ||
+    existing.house_number !== patientData.house_number ||
+    existing.postal_code !== patientData.postal_code ||
+    existing.city !== patientData.city
+
   const { error } = await supabase
     .from("patients")
-    .update(patientData)
+    .update(
+      // Mark pending on address change so the backfill/cron can recover if the
+      // fire-and-forget geocode below fails.
+      addressChanged ? { ...patientData, geocode_status: "pending" as const } : patientData
+    )
     .eq("id", id)
     .select()
     .single()
@@ -154,8 +175,10 @@ export async function updatePatient(
     metadata: { fields: Object.keys(patientData) },
   }).catch(() => {})
 
-  // Fire-and-forget geocoding (don't block the response)
-  if (patientData.street && patientData.house_number && patientData.postal_code && patientData.city) {
+  // Fire-and-forget geocoding — only when the address changed or was never
+  // geocoded (KM-07). House number is optional (KM-14).
+  const needsGeocode = addressChanged || existing?.geocode_status !== "success"
+  if (needsGeocode && patientData.street && patientData.postal_code && patientData.city) {
     geocodeAndUpdateRecord("patients", id, {
       street: patientData.street,
       house_number: patientData.house_number,

--- a/src/app/api/cron/geocode-backfill/route.test.ts
+++ b/src/app/api/cron/geocode-backfill/route.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+const { mockBatch, mockAdmin } = vi.hoisted(() => ({
+  mockBatch: vi.fn(),
+  mockAdmin: vi.fn(() => ({})),
+}))
+
+vi.mock("server-only", () => ({}))
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: mockAdmin }))
+vi.mock("@/lib/maps/geocode-batch", () => ({ processGeocodingBatch: mockBatch }))
+
+import { GET } from "./route"
+
+function req(auth?: string): Request {
+  return new Request("https://x/api/cron/geocode-backfill", {
+    headers: auth ? { authorization: auth } : {},
+  })
+}
+
+describe("geocode-backfill cron route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.CRON_SECRET = "s3cret"
+  })
+  afterEach(() => {
+    delete process.env.CRON_SECRET
+  })
+
+  it("returns 401 without an authorization header", async () => {
+    const res = await GET(req())
+    expect(res.status).toBe(401)
+    expect(mockBatch).not.toHaveBeenCalled()
+  })
+
+  it("returns 401 with a wrong secret", async () => {
+    const res = await GET(req("Bearer nope"))
+    expect(res.status).toBe(401)
+    expect(mockBatch).not.toHaveBeenCalled()
+  })
+
+  it("returns 401 when CRON_SECRET is not configured", async () => {
+    delete process.env.CRON_SECRET
+    const res = await GET(req("Bearer s3cret"))
+    expect(res.status).toBe(401)
+  })
+
+  it("processes a single batch and returns aggregated counts", async () => {
+    mockBatch.mockResolvedValue({
+      processed: 3, succeeded: 3, failed: 0, remaining: 0, cursor: "c1", errors: [],
+    })
+
+    const res = await GET(req("Bearer s3cret"))
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toMatchObject({ success: true, processed: 3, succeeded: 3, failed: 0, remaining: 0 })
+    expect(mockBatch).toHaveBeenCalledTimes(1)
+  })
+
+  it("loops across batches until remaining reaches 0", async () => {
+    mockBatch
+      .mockResolvedValueOnce({ processed: 50, succeeded: 48, failed: 2, remaining: 10, cursor: "c1", errors: [] })
+      .mockResolvedValueOnce({ processed: 10, succeeded: 10, failed: 0, remaining: 0, cursor: "c1", errors: [] })
+
+    const res = await GET(req("Bearer s3cret"))
+    const body = await res.json()
+
+    expect(mockBatch).toHaveBeenCalledTimes(2)
+    // Second call reuses the cursor from the first.
+    expect(mockBatch.mock.calls[1]?.[2]).toBe("c1")
+    expect(body).toMatchObject({ processed: 60, succeeded: 58, failed: 2, remaining: 0 })
+  })
+
+  it("returns 500 when the batch throws", async () => {
+    mockBatch.mockRejectedValue(new Error("boom"))
+    const res = await GET(req("Bearer s3cret"))
+    expect(res.status).toBe(500)
+  })
+})

--- a/src/app/api/cron/geocode-backfill/route.ts
+++ b/src/app/api/cron/geocode-backfill/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server"
+import { createAdminClient } from "@/lib/supabase/admin"
+import { processGeocodingBatch } from "@/lib/maps/geocode-batch"
+
+/**
+ * Vercel Cron endpoint: geocoding safety-net.
+ *
+ * Processes any records still needing geocoding (pending/failed/null with a
+ * usable address) that on-create/on-update geocoding missed — e.g. transient
+ * Google errors or records marked pending by a change-detection update.
+ *
+ * Idempotent and self-terminating: uses processGeocodingBatch's session cursor
+ * so each record is attempted at most once per run; a no-op when nothing is
+ * pending. Bounded per invocation by record count and wall-clock to stay under
+ * the serverless time budget.
+ *
+ * Auth: CRON_SECRET in the Authorization header (Vercel sets this).
+ */
+
+export const maxDuration = 60
+
+const BATCH_SIZE = 50
+const MAX_RECORDS_PER_RUN = 300
+const TIME_BUDGET_MS = 45_000
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("authorization")
+  const cronSecret = process.env.CRON_SECRET
+
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const supabase = createAdminClient()
+  const startedAt = Date.now()
+
+  let cursor: string | undefined
+  let processed = 0
+  let succeeded = 0
+  let failed = 0
+  let remaining = 0
+
+  try {
+    for (;;) {
+      const res = await processGeocodingBatch(supabase, BATCH_SIZE, cursor)
+      cursor = res.cursor
+      processed += res.processed
+      succeeded += res.succeeded
+      failed += res.failed
+      remaining = res.remaining
+
+      if (res.remaining === 0 || res.processed === 0) break
+      if (processed >= MAX_RECORDS_PER_RUN) break
+      if (Date.now() - startedAt >= TIME_BUDGET_MS) break
+    }
+
+    return NextResponse.json({ success: true, processed, succeeded, failed, remaining })
+  } catch (err) {
+    console.error("Geocode backfill cron failed:", err)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/acceptance-check",
       "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/cron/geocode-backfill",
+      "schedule": "30 4 * * *"
     }
   ]
 }


### PR DESCRIPTION
Schritt 1 des Milestones **Karten fixen** (#7) abschließend: automatischer Nachzug + weniger überflüssige Google-Calls.

## KM-06 — Cron-Safety-Net (#112)
- Neue Route `GET /api/cron/geocode-backfill` (mit `CRON_SECRET` geschützt): treibt `processGeocodingBatch` mit **Admin-Client** in einer gebündelten Schleife (Record- + Zeitbudget) bis nichts mehr pending ist.
- Fängt On-Create/On-Update-Fehlschläge und change-detection-`pending`s automatisch nach. **No-op**, wenn nichts pending ist (kostengünstig).
- In `vercel.json` täglich (`30 4 * * *`) — kann auf Pro-Plan höher getaktet werden.
- Tests: 401 ohne/falschem Secret, Aggregation, Loop bis `remaining=0`, 500 bei Fehler.

## KM-07 — Change-Detection (#113)
- `updatePatient`/`updateDestination` laden vorab die aktuelle Adresse + `geocode_status` und geocoden **nur** bei tatsächlicher Adressänderung oder wenn noch nicht `success` → kein Google-Call bei jedem Edit.
- Bei Adressänderung wird `geocode_status='pending'` gesetzt, damit Backfill/Cron nachziehen, falls das Fire-and-forget-Geocoding fehlschlägt.
- Create/Update-Bedingungen verlangen keine Hausnummer mehr (KM-14-Konsistenz).

## Verifikation
- Typecheck ✅ · Lint ✅ · **756 Tests** ✅ (6 neue) · `next build` ✅ (Route `/api/cron/geocode-backfill` registriert)

Closes #112
Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)