### PR TITLE
fix(maps): Directions-Fetch entfernen + ESLint-Guard (KM-09, KM-02)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,20 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "Literal[value=/maps\\.googleapis\\.com\\/maps\\/api\\/(geocode|directions|place)/]",
+        "message": "Google-Maps-Web-Service-Calls (Geocoding/Directions/Places) duerfen nicht direkt gefetcht werden. Nutze die zentralen Wrapper in src/lib/maps/* (Server-Key). Ein referer-beschraenkter Browser-Key funktioniert fuer diese Web-Services nicht. Static Maps (staticmap) sind hiervon nicht betroffen."
+      }
+    ]
+  },
+  "overrides": [
+    {
+      "files": ["src/lib/maps/**"],
+      "rules": {
+        "no-restricted-syntax": "off"
+      }
+    }
+  ]
 }

--- a/src/components/rides/ride-detail-map.tsx
+++ b/src/components/rides/ride-detail-map.tsx
@@ -10,29 +10,7 @@ interface RideDetailMapProps {
   polyline?: string | null
 }
 
-async function fetchRoutePolyline(
-// ... rest of fetchRoutePolyline
-  originLat: number,
-  originLng: number,
-  destLat: number,
-  destLng: number,
-  apiKey: string
-): Promise<string | null> {
-  try {
-    const res = await fetch(
-      `https://maps.googleapis.com/maps/api/directions/json?origin=${originLat},${originLng}&destination=${destLat},${destLng}&mode=driving&key=${apiKey}`,
-      { next: { revalidate: 86400 } }
-    )
-    if (!res.ok) return null
-    const data = await res.json()
-    const polyline = data.routes?.[0]?.overview_polyline?.points as string | undefined
-    return polyline ?? null
-  } catch {
-    return null
-  }
-}
-
-export async function RideDetailMap({
+export function RideDetailMap({
   originLat,
   originLng,
   destLat,
@@ -51,7 +29,7 @@ export async function RideDetailMap({
     return null
   }
 
-  const polyline = initialPolyline ?? await fetchRoutePolyline(originLat, originLng, destLat, destLng, apiKey)
+  const polyline = initialPolyline ?? null
 
   const params = new URLSearchParams({
     size: "640x300",


### PR DESCRIPTION
Start von **Schritt 2** + Regressions-Schutz. Von zwei Subagenten parallel umgesetzt (disjunkte Dateien), zentral verifiziert.

## KM-09 — zweiter Referer-Bug behoben (#116)
`RideDetailMap` war eine async Server Component, die im Fallback (keine gecachte Polyline) den **Directions-Web-Service serverseitig mit dem referer-beschränkten `NEXT_PUBLIC`-Key** aufrief → gleiche Fehlerklasse wie der ursprüngliche Bug.
- `fetchRoutePolyline` komplett entfernt; Komponente ist jetzt **synchron** und nutzt die persistierte `ride.polyline` (fehlt sie → Static Map ohne Routenlinie, Marker bleiben). Kein Directions-Call im Render.
- Static-Map-`<img>` behält den `NEXT_PUBLIC`-Key (für Browser-Bilder korrekt).

## KM-02 — ESLint-Guard (#114)
`no-restricted-syntax`-Regel, die String-Literale zu `maps.googleapis.com/maps/api/(geocode|directions|place)` als Fehler markiert, mit Ausnahme für `src/lib/maps/**`. Verhindert strukturell künftige Key-Verwechslungen. `staticmap` wird bewusst nicht geblockt.

## Verifikation (zentral)
- Typecheck ✅ · **756 Tests** ✅ · `next build` ✅ · Lint ✅
- ESLint-Regel per Probe geprüft: Verstoß außerhalb `lib/maps` → **Error**; innerhalb `lib/maps` → exempt; `staticmap` → erlaubt.

Closes #116
Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)