### PR TITLE
M13 – Fahrt-Erfassung (One-Page-Dispo)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ next-env.d.ts
 *.cert
 .turbo/
 .vercel
+.claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -583,3 +583,20 @@ Expected: `role = 'driver'` **and** a non-NULL `driver_id`. If you see `role = '
 
 - Someone changed the database schema but did not regenerate and commit the types file.
 - Run `npm run db:types` locally, verify the diff, and commit the updated `src/lib/types/database.ts`.
+
+## Fahrt erfassen (One-Page-Dispo)
+
+Milestone **M13** adds a dedicated ride-capture page at `/rides/erfassen` — a two-column "One-Page-Dispo" screen for dispatchers. The left column captures **who → where → when**; the right column shows the map, the back-calculated pickup time(s) and the price **live**, without saving.
+
+Key ideas:
+
+- **Time model** (`src/lib/rides/time-calc.ts`): outbound pickup = appointment start − drive time − pickup buffer − boarding; return pickup = appointment end + return buffer; appointment end = appointment start + duration. The three buffers are org-wide defaults (`organization_settings`, loaded via `loadRideTimeBuffers`) and overridable per ride.
+- **Round trip = two linked rides**: the return leg is a separate `rides` row with `direction=return` and `parent_ride_id` pointing at the outbound (ADR-008).
+- **Cost bearer** lives on the patient (`cost_bearer`), never on the ride. **Requirements** (`ride_requirement[]`) live on the ride; only `wheelchair` influences the vehicle type (`requirementsToVehicleType`).
+- **Never block**: missing geocoding, price or appointment time produce non-blocking `warnings` (`collectRideWarnings`) instead of hard errors — `createRide` saves and returns `success: true` with warnings instead of redirecting. `save_intent=order_sheet` suppresses the redirect so the M11 order sheet can open.
+- **Driver assignment is out of scope** here — captured rides start `unplanned` and are assigned later in the dispatch board.
+
+The existing `ride-form.tsx` (editing) is unchanged. Design rationale: [ADR-014](docs/adrs/014-fahrt-erfassung.md). Dispatcher walkthrough: [docs/guides/fahrt-erfassen.md](docs/guides/fahrt-erfassen.md).
+
+---
+

--- a/docs/adrs/014-fahrt-erfassung.md
+++ b/docs/adrs/014-fahrt-erfassung.md
@@ -1,0 +1,228 @@
+# ADR-014: Fahrt-Erfassung (One-Page-Dispo, M13)
+
+## Status
+Accepted
+
+## Kontext
+
+Die bestehende Fahrt-Erfassung lief ueber `ride-form.tsx` — ein generisches
+Formular, das sowohl fuer das Anlegen als auch fuer das Bearbeiten einer Fahrt
+verwendet wurde. Fuer den taeglichen Dispo-Betrieb ist dieses Formular zu
+technisch: Der Disponent denkt in "Wer faehrt wohin und wann?", nicht in
+Datenbankfeldern wie `pickup_time`, `appointment_time` oder `duration_category`.
+
+Das alte Access-System hatte eine Ein-Seiten-Maske, in der die Disponentin die
+Fahrt links erfasste und rechts sofort Karte, berechnete Zeiten und Preis sah.
+M13 baut dieses Erlebnis als moderne "One-Page-Dispo" nach: eine dedizierte
+Route `/rides/erfassen` mit Zwei-Spalten-Layout, Live-Berechnung und einem
+"nie-blockieren"-Speicherfluss.
+
+Wesentliche fachliche Anforderungen:
+
+- Die Abholzeit soll aus dem **Termin** rueckgerechnet werden (der Disponent
+  kennt den Termin, nicht die Abholzeit).
+- Hin- und Rueckfahrt sollen in einem Schritt erfassbar sein.
+- Fehlende Geodaten, Preis oder Terminzeit duerfen das Speichern **nie**
+  verhindern — der Disponent soll "jetzt speichern, spaeter ergaenzen" koennen.
+- Kostentraeger und Transportbedarf sollen erfassbar sein.
+- Die Fahrerzuweisung ist bewusst **nicht** Teil dieses Flows.
+
+## Optionen
+
+### Route / Formular
+
+1. **Neue Route `/rides/erfassen` mit eigener `RideCaptureForm`** (gewaehlt) —
+   Klare Trennung von Erfassung (One-Page-Dispo) und Bearbeitung
+   (`ride-form.tsx`). Kein Risiko fuer den Edit-Flow.
+2. **`ride-form.tsx` ueberladen** — Ein Formular fuer alles. Wuerde das bereits
+   komplexe Formular mit Zwei-Spalten-Layout, Live-Karte und Terminlogik
+   ueberfrachten und den getesteten Edit-Pfad gefaehrden.
+3. **Modal/Dialog** — Zu wenig Platz fuer das Zwei-Spalten-Erlebnis mit Karte
+   und Preis-Breakdown. Der Quick-Capture-Dialog (G1/G2) deckt den schnellen
+   Fall bereits ab; `/rides/erfassen` ist die vollstaendige Variante.
+
+### Zeitberechnung
+
+1. **Client-orchestriert, Server-Actions fuer I/O** (gewaehlt) — Die reine
+   Zeitmathematik (`calculateRideTimes`) laeuft im Client fuer sofortiges
+   Feedback; Route/Preis kommen ueber Server-Actions (`calculateRouteForRide`,
+   Preis in `createRide`). Der Server bleibt autoritativ beim Speichern.
+2. **Alles serverseitig** — Kein Live-Feedback ohne Roundtrip. Schlechtere UX.
+3. **Alles clientseitig** — Maps-/Preis-Logik und -Keys gehoeren nicht in den
+   Client (Kosten, Secrets).
+
+### Hin + Rueck
+
+1. **Zwei verknuepfte `rides` ueber `parent_ride_id`** (gewaehlt) — Nutzt das
+   bestehende Feld aus ADR-008. Rueckfahrt ist eine eigenstaendige, unabhaengig
+   disponierbare Fahrt mit `direction=return` und Verweis auf die Hinfahrt.
+2. **Ein `rides`-Datensatz mit `direction=both`** — Vermischt zwei
+   Transportvorgaenge in einem Datensatz; erschwert getrennte Fahrerzuweisung,
+   Status und Abrechnung.
+
+## Entscheidung
+
+### E1: Neue Route `/rides/erfassen` + `RideCaptureForm`
+
+- Server-Component-Seite `src/app/(dashboard)/rides/erfassen/page.tsx` laedt
+  aktive Patienten, aktive Ziele und die Org-Zeitpuffer
+  (`loadRideTimeBuffers`) und reicht sie an die Client-Komponente
+  `RideCaptureForm` (`src/components/rides/ride-capture-form.tsx`).
+- `ride-form.tsx` (Bearbeiten) bleibt **unveraendert**. Erfassung und
+  Bearbeitung sind bewusst zwei getrennte Oberflaechen.
+- Deep-Link-Parameter (`?date=`, `?patient_id=`, `?destination_id=`)
+  vorbelegen Felder, damit aus Dashboard/Dispo direkt erfasst werden kann.
+
+### E2: Slot-Architektur
+
+`RideCaptureForm` ist der State-Kern; die Bausteine sind entkoppelte Slot-
+Komponenten unter `src/components/rides/capture/`:
+
+```
+ride-capture-form.tsx        -- State-Kern (Formular, alle useState/useMemo)
+capture/
+  types.ts                   -- geteilte Contracts (RouteInfo, CapturePatient, ...)
+  capture-patient-field.tsx  -- Patient waehlen/inline anlegen (#136/#137)
+  capture-destination-field.tsx
+  cost-bearer-display.tsx    -- Kostentraeger des Patienten (read-only, #125)
+  requirement-chips.tsx      -- Bedarf als Chip-Set (#135)
+  series-toggle.tsx          -- Serie (delegiert an bestehende Logik)
+  ride-map-panel.tsx         -- Live-Karte (#132)
+  ride-price-panel.tsx       -- Live-Preis-Breakdown (#133)
+  capture-save-actions.tsx   -- zwei Submit-Buttons (save_intent, #139)
+  save-result-panel.tsx      -- Post-Save-Panel mit Warnungen (#139)
+```
+
+Der Kern besitzt den gesamten State; Slots erhalten nur ihren Slice plus Setter
+ueber eigene `*Props`. Die geteilten Shapes liegen in `capture/types.ts`, um
+einen Zirkelimport zwischen Kern und Slots zu vermeiden.
+
+### E3: Zwei-Spalten-UX
+
+Layout `lg:grid-cols-[1fr_minmax(360px,440px)]`:
+
+- **Links (Erfassung):** Wer -> Wohin & Wann -> Bedarf/Serie. Fuehrt den
+  Disponenten in Lesereihenfolge durch den Vorgang.
+- **Rechts (Ergebnis, live):** Karte, berechnete Abholzeit(en), Preis-Breakdown.
+  Aktualisiert sich bei jeder Aenderung ohne Speichern.
+
+### E4: Rechenmodell
+
+Reine Funktion `calculateRideTimes` (`src/lib/rides/time-calc.ts`, #129):
+
+```
+Hinfahrt-Abholzeit  = Terminbeginn - Fahrzeit - Vorlauf(pickupBuffer) - Boarding
+Rueckfahrt-Abholzeit = Terminende + Rueck-Puffer(returnBuffer)
+Terminende          = Terminbeginn + Termindauer   (im Client abgeleitet)
+```
+
+- Die drei Puffer (`pickupBuffer`, `boarding`, `returnBuffer`) sind
+  **org-weite Defaults** aus `organization_settings` (#128), geladen ueber
+  `loadRideTimeBuffers` und nur zum Vorbelegen. Der Disponent kann die
+  vorgeschlagene Zeit jederzeit manuell ueberschreiben (`pickupManual`).
+- `duration_category` (`under_2h` / `over_2h`) wird aus der Termindauer
+  abgeleitet: `>= 120 min -> over_2h`. Sie speist den Duebendorf-Tarif
+  (ADR-010).
+- Ergibt eine Rechnung eine Zeit ausserhalb `00:00`-`23:59`, liefert die
+  Funktion `null` (kein Vorschlag) statt eines ungueltigen Werts.
+
+### E5: Hin + Rueck = zwei verknuepfte `rides`
+
+- Bei "Hin & Rueck" (`round_trip`, Default) legt `createRide` nach der Hinfahrt
+  eine zweite Fahrt mit `direction=return`, `status=unplanned` und
+  `parent_ride_id = <Hinfahrt>` an (Feld aus ADR-008).
+- Die Rueckfahrt-Abholzeit ist `return_pickup_time` oder, falls leer,
+  `Terminende + returnBuffer`.
+- Scheitert die Rueckfahrt, bleibt die Hinfahrt bestehen (geloggt, nicht
+  blockierend) — konsistent mit dem "nie-blockieren"-Prinzip.
+
+### E6: Kostentraeger am Patienten
+
+Der Kostentraeger (`cost_bearer`, #125) haengt ausschliesslich am **Patienten**,
+nie an der Fahrt. Im Erfassungsflow wird er nur read-only angezeigt
+(`cost-bearer-display.tsx`); Pflege erfolgt ueber die Patientenformulare
+(`patientSchema` / `patientInlineSchema`). Enum:
+`health_insurance | self_payer | municipality | other`, optional (NULL erlaubt).
+
+### E7: Bedarf als `ride_requirement`-Set
+
+Der Transportbedarf (#126) ist ein Set auf **Fahrtebene** (`rides.requirements`,
+`ride_requirement[]`, NOT NULL DEFAULT `{}`): `wheelchair | rollator |
+companion | oxygen | carry_chair | stretcher`. Ein neues Enum (nicht
+`impairment_type`), bewusst als Superset plus `oxygen`/`carry_chair`.
+
+- `requirementsToVehicleType` (`src/lib/rides/requirements.ts`) mappt nur
+  `wheelchair -> wheelchair`, alles andere -> `standard`. `vehicle_type` wird in
+  M13 **nicht** erweitert; `oxygen`/`carry_chair`/`stretcher` bleiben rein
+  informative Flags.
+- `companion` impliziert immer einen Begleitschutz (`has_escort=true`), da beide
+  denselben realen Sachverhalt abbilden (`resolveHasEscort`).
+
+### E8: "Nie-blockieren"-Prinzip
+
+Fehlende Geodaten, nicht berechenbarer Preis oder fehlende Terminzeit erzeugen
+**strukturierte, nicht-blockierende Warnungen** statt harter Feldfehler
+(`collectRideWarnings`, `src/lib/rides/warnings.ts`, #130):
+
+- `createRide` speichert die Fahrt immer (sofern die Pflichtfelder valide sind)
+  und gibt bei Warnungen `success: true` mit `warnings[]` zurueck, **ohne**
+  weiterzuleiten. Das Post-Save-Panel (#139) zeigt die Warnungen; der Disponent
+  bleibt auf der Seite.
+- Preis-/Routenberechnung ist "best effort" in einem `try/catch` — eine
+  Ausnahme bricht das Speichern nie ab.
+- `save_intent` steuert die Navigation: `list` leitet nach dem sauberen
+  Speichern zur Tagesansicht (`/rides?date=`); `order_sheet` unterdrueckt die
+  Weiterleitung, damit das M11-Auftragsblatt geoeffnet werden kann.
+
+### E9: Fahrerzuweisung out-of-scope
+
+Die Erfassung legt Fahrten mit `status=unplanned` (kein Fahrer) an. Die
+Fahrerzuweisung passiert bewusst spaeter im Dispo-Board — das trennt "Auftrag
+erfassen" sauber von "Auftrag disponieren" und haelt die One-Page-Maske schlank.
+
+## Konsequenzen
+
+### Positiv
+- Disponentengerechte Maske: Termin rein, Abholzeit + Preis + Karte raus.
+- Kein Risiko fuer den bestehenden Edit-Flow (`ride-form.tsx` unangetastet).
+- Reine, testbare Kernlogik (`calculateRideTimes`, `requirementsToVehicleType`,
+  `collectRideWarnings`) ohne DB-/React-Abhaengigkeiten.
+- "Nie-blockieren" verhindert Dateneingabe-Sackgassen im Tagesbetrieb.
+- Hin/Rueck als getrennte Fahrten bleiben unabhaengig disponier- und abrechenbar.
+
+### Negativ
+- Zwei Erfassungs-Einstiege (Quick-Capture-Dialog + `/rides/erfassen`), die
+  parallel gepflegt werden muessen.
+- Zwei Zeit-Puffer-Quellen (Org-Default vs. manuelle Ueberschreibung) erfordern
+  klare UI-Signale, welcher Wert gerade greift.
+
+### Risiken
+- Die Ableitungen `appointment_end_time` und `duration_category` liegen inline
+  in der Client-Komponente. Der zugrunde liegende Baustein (`addMinutesToTime`)
+  ist reine, getestete Logik; die Verdrahtung der `>= 120 min`-Schwelle wird
+  ueber die Tarif-Vorschau im Browser manuell verifiziert (siehe Tests unten).
+- Der Preis-Trigger haengt an vollstaendigen Geodaten. Nicht geocodierte
+  Adressen liefern bewusst nur eine Warnung, keinen Preis.
+
+## Tests
+
+Reine Logik ist per Vitest abgedeckt (echter Test):
+
+- `calculateRideTimes` / `detectTimeConflicts` — `src/lib/rides/__tests__/time-calc.test.ts`
+- `requirementsToVehicleType` — `src/lib/rides/__tests__/requirements.test.ts`
+- `collectRideWarnings` — `src/lib/rides/__tests__/warnings.test.ts`
+- `loadRideTimeBuffers` (Stub-Client) — `src/lib/rides/__tests__/time-buffers.test.ts`
+- Org-Zeitpuffer-Zod (#128) — `src/lib/validations/__tests__/organization.test.ts`
+- Kostentraeger-Zod (#125) — `src/lib/validations/__tests__/patients-cost-bearer.test.ts`
+- Bedarf-Zod (#126) — `src/lib/validations/__tests__/ride-requirements-schema.test.ts`
+- `appointment_end_time`-Arithmetik — `src/lib/rides/__tests__/appointment-end-derivation.test.ts`
+- `createRide` "nie-blockieren" + `save_intent` (gemockt) —
+  `src/actions/__tests__/create-ride.test.ts`
+
+Manuell / DB-seitig verifiziert (kein automatisierter Test):
+
+- End-to-End-Erfassungsfluss inkl. Live-Karte im Browser.
+- `>= 120 min -> over_2h`-Schwelle als Inline-Ternary in der Komponente
+  (Downstream-Tarif ist getestet).
+- Return-Ride-Erzeugung, Serien-Delegation und Fahrer-Verfuegbarkeits-Guard in
+  `createRide` (RLS-/DB-abhaengig).

--- a/docs/guides/fahrt-erfassen.md
+++ b/docs/guides/fahrt-erfassen.md
@@ -1,0 +1,85 @@
+# Fahrt erfassen (One-Page-Dispo)
+
+Diese Kurzanleitung richtet sich an Disponentinnen und Disponenten. Sie zeigt,
+wie Sie auf der Seite **Fahrt erfassen** eine neue Fahrt anlegen — links
+eingeben, rechts sofort das Ergebnis sehen.
+
+Die Seite erreichen Sie unter **Fahrten → Fahrt erfassen**
+([`/rides/erfassen`](/rides/erfassen)) oder direkt aus dem Dashboard.
+
+Architektur- und Design-Hintergrund: siehe
+[ADR-014](../adrs/014-fahrt-erfassung.md).
+
+---
+
+## Das Prinzip: links erfassen, rechts live sehen
+
+Die Seite hat zwei Spalten:
+
+- **Links** geben Sie ein: **Wer** fährt **wohin** und **wann** ist der Termin.
+- **Rechts** erscheint sofort das Ergebnis: Karte, berechnete Abholzeit(en) und
+  der Preis. Sie müssen dafür nichts speichern — die rechte Spalte rechnet bei
+  jeder Änderung mit.
+
+---
+
+## Schritt für Schritt
+
+1. **Wer:** Patient auswählen. Ist die Person noch nicht erfasst, legen Sie sie
+   direkt hier an. Der **Kostenträger** (z. B. Krankenkasse, Gemeinde) wird zum
+   Patienten angezeigt — er wird beim Patienten gepflegt, nicht bei der Fahrt.
+2. **Wohin:** Ziel auswählen. Sobald Patient und Ziel stehen, berechnet die App
+   automatisch die **Route** und zeigt sie rechts auf der Karte.
+3. **Wann:** **Terminbeginn** und **Termindauer** eingeben. Daraus leitet die
+   App ab:
+   - **Abholzeit Hinfahrt** = Terminbeginn − Fahrzeit − Vorlauf − Einsteigezeit
+   - **Terminende** = Terminbeginn + Termindauer
+   - **Abholzeit Rückfahrt** = Terminende + Puffer
+   Die vorgeschlagene Abholzeit können Sie jederzeit **manuell überschreiben**.
+4. **Hin & Rück:** Standardmäßig wird eine **Hin- und eine Rückfahrt** angelegt
+   (zwei verknüpfte Fahrten). Für eine reine Einzelfahrt stellen Sie auf
+   **Einzelfahrt** um.
+5. **Bedarf:** Transportbedarf als Chips wählen (Rollstuhl, Rollator, Begleitung,
+   Sauerstoff, Tragestuhl, Trage). Rollstuhl bestimmt den Fahrzeugtyp; die
+   übrigen sind informative Hinweise für die Fahrerin oder den Fahrer.
+6. **Speichern:** Zwei Möglichkeiten:
+   - **Speichern & zur Übersicht** — legt die Fahrt an und springt zur
+     Tagesansicht.
+   - **Auftragsblatt** — legt die Fahrt an und öffnet das Auftragsblatt, ohne
+     wegzuspringen.
+
+---
+
+## Wichtig: Speichern wird nie blockiert
+
+Sie können **jederzeit speichern**, auch wenn noch etwas fehlt. Die App
+verhindert das Speichern nie wegen fehlender Geodaten, fehlendem Preis oder
+fehlender Terminzeit. Stattdessen erscheint nach dem Speichern ein Hinweis, z. B.:
+
+- „Die Patientenadresse ist noch nicht geocodiert.“ → Route/Preis konnten nicht
+  berechnet werden.
+- „Der Preis konnte nicht automatisch berechnet werden.“ → später prüfen oder
+  manuell erfassen.
+- „Es ist kein Terminbeginn erfasst.“ → keine Abholzeit-Vorschläge möglich.
+
+Das Motto lautet: **jetzt erfassen, später ergänzen.** Die Fahrt ist gespeichert
+und im Dispo-Board sichtbar; die Hinweise können Sie in Ruhe abarbeiten.
+
+---
+
+## Was diese Seite bewusst nicht macht
+
+- **Keine Fahrerzuweisung.** Neu erfasste Fahrten sind zunächst „ungeplant“. Die
+  Fahrerin oder den Fahrer weisen Sie anschließend im **Dispo-Board** zu. So
+  bleibt das Erfassen schlank und das Disponieren an einem Ort.
+- **Kein Bearbeiten.** Bestehende Fahrten ändern Sie weiterhin über das
+  Fahrt-Bearbeiten-Formular, nicht hier.
+
+---
+
+## Verwandte Einstellungen
+
+Die Puffer für die Zeitberechnung (Vorlauf, Einsteigezeit, Rückfahrt-Puffer)
+sind organisationsweite Vorgaben und werden unter **Einstellungen** gepflegt.
+Sie gelten als Startwert für den Vorschlag und können pro Fahrt überschrieben
+werden.

--- a/src/actions/__tests__/create-ride.test.ts
+++ b/src/actions/__tests__/create-ride.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+/**
+ * createRide — "never-block" persistence + save_intent behavior (Issue #130/#139, M13).
+ *
+ * These are server-action-level tests analogous to `rides.test.ts`: the whole
+ * Supabase client, auth, price calculation, telemetry, audit and navigation are
+ * mocked, so no DB is touched. They pin the two behaviors that make the capture
+ * page (#131/#139) work:
+ *
+ *   1. Missing geocoding / price / appointment time NEVER blocks the save. The
+ *      ride is inserted and the action returns `success: true` with structured,
+ *      non-blocking `warnings` instead of redirecting away.
+ *   2. `save_intent=order_sheet` suppresses the post-save redirect even on a
+ *      clean save, so the form can open the M11 order sheet; the default
+ *      (`list`) redirects to the day view.
+ *
+ * Honest scope: the return-ride branch, the series delegation and the driver
+ * availability guard are NOT exercised here — they are covered by DB-side /
+ * manual verification (see ADR-014). The `from()` stub only implements the
+ * chains the tested paths hit.
+ */
+
+// ---------------------------------------------------------------------------
+// Hoisted mock handles
+// ---------------------------------------------------------------------------
+
+vi.mock("server-only", () => ({}))
+
+const h = vi.hoisted(() => ({
+  createClient: vi.fn(),
+  requireAuth: vi.fn(),
+  calcPrice: vi.fn(),
+  isPriceFailure: vi.fn(),
+  redirect: vi.fn((url: string) => {
+    // Mirror Next.js: redirect() interrupts by throwing.
+    throw new Error(`NEXT_REDIRECT:${url}`)
+  }),
+  revalidatePath: vi.fn(),
+  trackEvent: vi.fn(),
+  logAudit: vi.fn().mockResolvedValue(undefined),
+  loadRideTimeBuffers: vi.fn().mockResolvedValue({
+    pickupBufferMinutes: 5,
+    boardingMinutes: 0,
+    returnBufferMinutes: 15,
+  }),
+}))
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: h.createClient }))
+vi.mock("@/lib/auth/require-auth", () => ({ requireAuth: h.requireAuth }))
+vi.mock("@/lib/billing/calculate-price", () => ({
+  calculateRidePrice: h.calcPrice,
+  isPriceCalculationFailure: h.isPriceFailure,
+}))
+vi.mock("next/navigation", () => ({ redirect: h.redirect }))
+vi.mock("next/cache", () => ({ revalidatePath: h.revalidatePath }))
+vi.mock("@/lib/telemetry", () => ({ trackEvent: h.trackEvent }))
+vi.mock("@/lib/audit/logger", () => ({ logAudit: h.logAudit }))
+vi.mock("@/lib/rides/time-buffers", () => ({
+  loadRideTimeBuffers: h.loadRideTimeBuffers,
+}))
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { createRide } from "../rides"
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+type GeoRow = {
+  postal_code: string | null
+  lat: number | null
+  lng: number | null
+  geocode_status: string
+  display_name?: string
+}
+
+interface ClientOpts {
+  patient: GeoRow
+  destination: GeoRow
+  insertedRide: Record<string, unknown>
+  insertError?: { message: string } | null
+}
+
+/** Build a table-aware Supabase stub covering only the chains createRide hits. */
+function makeClient({
+  patient,
+  destination,
+  insertedRide,
+  insertError = null,
+}: ClientOpts) {
+  const rideInsert = vi.fn(() => ({
+    select: () => ({
+      single: () =>
+        Promise.resolve({ data: insertedRide, error: insertError }),
+    }),
+  }))
+
+  const from = vi.fn((table: string) => {
+    if (table === "patients") {
+      return {
+        select: () => ({
+          eq: () => ({
+            single: () => Promise.resolve({ data: patient, error: null }),
+          }),
+        }),
+      }
+    }
+    if (table === "destinations") {
+      return {
+        select: () => ({
+          eq: () => ({
+            single: () => Promise.resolve({ data: destination, error: null }),
+          }),
+        }),
+      }
+    }
+    if (table === "rides") {
+      return { insert: rideInsert }
+    }
+    // Fallback for any incidental table access.
+    return {
+      select: () => ({
+        eq: () => ({
+          single: () => Promise.resolve({ data: null, error: null }),
+        }),
+      }),
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    }
+  })
+
+  return { from }
+}
+
+const PATIENT_ID = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+const DEST_ID = "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22"
+
+/** Build a FormData for the capture form. */
+function buildFormData(
+  fields: Record<string, string> = {}
+): FormData {
+  const fd = new FormData()
+  fd.set("patient_id", PATIENT_ID)
+  fd.set("destination_id", DEST_ID)
+  fd.set("date", "2026-03-15")
+  fd.set("pickup_time", "08:30")
+  fd.set("direction", "outbound")
+  for (const [k, v] of Object.entries(fields)) fd.set(k, v)
+  return fd
+}
+
+const geocoded: GeoRow = {
+  postal_code: "8600",
+  lat: 47.39,
+  lng: 8.62,
+  geocode_status: "success",
+  display_name: "Spital Uster",
+}
+
+const notGeocoded: GeoRow = {
+  postal_code: "8600",
+  lat: null,
+  lng: null,
+  geocode_status: "pending",
+  display_name: "Spital Uster",
+}
+
+const successfulPrice = {
+  distance_meters: 5000,
+  duration_seconds: 600,
+  calculated_price: 12,
+  fare_rule_id: null,
+  tariff_zone: "gemeinde",
+  surcharge_amount: 0,
+  breakdown: [] as unknown[],
+  polyline: null,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createRide — never-block (#130)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    h.requireAuth.mockResolvedValue({
+      authorized: true,
+      userId: "user-1",
+      role: "operator",
+      driverId: null,
+    })
+    h.loadRideTimeBuffers.mockResolvedValue({
+      pickupBufferMinutes: 5,
+      boardingMinutes: 0,
+      returnBufferMinutes: 15,
+    })
+    h.logAudit.mockResolvedValue(undefined)
+  })
+
+  it("saves and returns warnings instead of redirecting when nothing is geocoded", async () => {
+    h.createClient.mockResolvedValue(
+      makeClient({
+        patient: notGeocoded,
+        destination: notGeocoded,
+        insertedRide: { id: "ride-1", date: "2026-03-15" },
+      })
+    )
+
+    const result = await createRide(null, buildFormData())
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toMatchObject({ id: "ride-1" })
+      const codes = (result.warnings ?? []).map((w) => w.code)
+      expect(codes).toEqual([
+        "patient_not_geocoded",
+        "destination_not_geocoded",
+        "price_not_calculated",
+        "appointment_time_missing",
+      ])
+    }
+    // Never navigated away.
+    expect(h.redirect).not.toHaveBeenCalled()
+  })
+
+  it("never calls the price calculation when coordinates are missing", async () => {
+    h.createClient.mockResolvedValue(
+      makeClient({
+        patient: notGeocoded,
+        destination: notGeocoded,
+        insertedRide: { id: "ride-2" },
+      })
+    )
+
+    await createRide(null, buildFormData())
+
+    expect(h.calcPrice).not.toHaveBeenCalled()
+  })
+
+  it("returns a field error and does not insert when validation fails", async () => {
+    const insertedRide = { id: "should-not-happen" }
+    const client = makeClient({
+      patient: geocoded,
+      destination: geocoded,
+      insertedRide,
+    })
+    h.createClient.mockResolvedValue(client)
+
+    const fd = buildFormData()
+    fd.set("patient_id", "not-a-uuid")
+
+    const result = await createRide(null, fd)
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.fieldErrors?.patient_id).toBeDefined()
+    }
+    // No ride table access on the validation-failure path.
+    expect(client.from).not.toHaveBeenCalledWith("rides")
+  })
+
+  it("still returns the created ride when geocoded but the appointment time is missing", async () => {
+    h.calcPrice.mockResolvedValue(successfulPrice)
+    h.isPriceFailure.mockReturnValue(false)
+    h.createClient.mockResolvedValue(
+      makeClient({
+        patient: geocoded,
+        destination: geocoded,
+        insertedRide: { id: "ride-3" },
+      })
+    )
+
+    const result = await createRide(null, buildFormData())
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      const codes = (result.warnings ?? []).map((w) => w.code)
+      // Geo + price resolved -> only the appointment-time warning remains.
+      expect(codes).toEqual(["appointment_time_missing"])
+    }
+    expect(h.redirect).not.toHaveBeenCalled()
+  })
+})
+
+describe("createRide — save_intent (#139)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    h.requireAuth.mockResolvedValue({
+      authorized: true,
+      userId: "user-1",
+      role: "operator",
+      driverId: null,
+    })
+    h.calcPrice.mockResolvedValue(successfulPrice)
+    h.isPriceFailure.mockReturnValue(false)
+    h.logAudit.mockResolvedValue(undefined)
+  })
+
+  it("redirects to the day view on a clean save with save_intent=list", async () => {
+    h.createClient.mockResolvedValue(
+      makeClient({
+        patient: geocoded,
+        destination: geocoded,
+        insertedRide: { id: "ride-4", date: "2026-03-15" },
+      })
+    )
+
+    await expect(
+      createRide(
+        null,
+        buildFormData({ appointment_time: "09:00", save_intent: "list" })
+      )
+    ).rejects.toThrow("NEXT_REDIRECT:/rides?date=2026-03-15")
+
+    expect(h.redirect).toHaveBeenCalledWith("/rides?date=2026-03-15")
+  })
+
+  it("skips the redirect on a clean save with save_intent=order_sheet", async () => {
+    h.createClient.mockResolvedValue(
+      makeClient({
+        patient: geocoded,
+        destination: geocoded,
+        insertedRide: { id: "ride-5", date: "2026-03-15" },
+      })
+    )
+
+    const result = await createRide(
+      null,
+      buildFormData({ appointment_time: "09:00", save_intent: "order_sheet" })
+    )
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toMatchObject({ id: "ride-5" })
+      // Clean save -> no warnings, but redirect is suppressed for the order sheet.
+      expect(result.warnings ?? []).toEqual([])
+    }
+    expect(h.redirect).not.toHaveBeenCalled()
+  })
+})
+
+describe("createRide — auth guard", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("rejects unauthenticated callers before touching the DB", async () => {
+    h.requireAuth.mockResolvedValue({
+      authorized: false,
+      error: "Nicht authentifiziert",
+    })
+
+    const result = await createRide(null, buildFormData())
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe("Nicht authentifiziert")
+    }
+    expect(h.createClient).not.toHaveBeenCalled()
+  })
+})

--- a/src/actions/organization.ts
+++ b/src/actions/organization.ts
@@ -5,10 +5,31 @@ import { createClient } from "@/lib/supabase/server"
 import { requireAdmin } from "@/lib/auth/require-admin"
 import { updateOrganizationSchema } from "@/lib/validations/organization"
 import type { ActionResult } from "@/actions/shared"
-import type { Tables } from "@/lib/types/database"
+import type { Database, Tables } from "@/lib/types/database"
 
-// Use the auto-generated type from Supabase
-export type OrganizationSettings = Tables<"organization_settings">
+// -----------------------------------------------------------------------------
+// TYPE NOTE (Issue #128):
+// The time-buffer columns are added in migration
+// 20260329_000001_org_settings_time_buffers.sql. The generated Supabase types
+// (src/lib/types/database.ts) are regenerated centrally AFTER this branch is
+// merged, so they do not know these columns yet. We augment the generated Row
+// and Update types locally so app code stays type-safe and `tsc` stays green.
+// Cast sites are marked below. Once the types are regenerated, the intersections
+// become redundant no-ops and can be removed.
+// -----------------------------------------------------------------------------
+type TimeBufferColumns = {
+  default_pickup_buffer_minutes: number
+  default_boarding_minutes: number
+  default_return_buffer_minutes: number
+}
+
+// Use the auto-generated type from Supabase, augmented with the new columns.
+export type OrganizationSettings = Tables<"organization_settings"> &
+  TimeBufferColumns
+
+type OrganizationSettingsUpdate =
+  Database["public"]["Tables"]["organization_settings"]["Update"] &
+    Partial<TimeBufferColumns>
 
 // =============================================================================
 // GET ORGANIZATION SETTINGS
@@ -27,7 +48,9 @@ export async function getOrganizationSettings(): Promise<OrganizationSettings | 
     return null
   }
 
-  return data
+  // Cast: `data` lacks the time-buffer columns in the generated types (see
+  // TYPE NOTE above); the DB row does include them post-migration.
+  return data as unknown as OrganizationSettings
 }
 
 // =============================================================================
@@ -66,9 +89,11 @@ export async function updateOrganizationSettings(
     return { success: false, error: "Organisationseinstellungen nicht gefunden" }
   }
 
+  // Cast: `result.data` now carries the time-buffer fields, which the generated
+  // Update type does not know yet (see TYPE NOTE above).
   const { data, error } = await supabase
     .from("organization_settings")
-    .update(result.data)
+    .update(result.data as OrganizationSettingsUpdate)
     .eq("id", current.id)
     .select()
     .single()
@@ -79,7 +104,7 @@ export async function updateOrganizationSettings(
   }
 
   revalidatePath("/settings")
-  return { success: true, data }
+  return { success: true, data: data as unknown as OrganizationSettings }
 }
 
 // =============================================================================

--- a/src/actions/patients.ts
+++ b/src/actions/patients.ts
@@ -9,7 +9,19 @@ import { geocodeAndUpdateRecord } from "@/lib/maps/geocode"
 import { logAudit } from "@/lib/audit/logger"
 import { uuidSchema } from "@/lib/validations/shared"
 import type { ActionResult } from "@/actions/shared"
-import type { Tables } from "@/lib/types/database"
+import type { Tables, TablesInsert, TablesUpdate } from "@/lib/types/database"
+import type { CostBearer } from "@/lib/patients/constants"
+
+// #125: the generated DB types don't yet include patients.cost_bearer (they are
+// regenerated centrally after the M13 merge). Extend the write payload types
+// locally so the new column is written type-safely — no `any`, no @ts-ignore.
+// Drop these intersections once database.ts is regenerated.
+type PatientInsertPayload = TablesInsert<"patients"> & {
+  cost_bearer?: CostBearer | null
+}
+type PatientUpdatePayload = TablesUpdate<"patients"> & {
+  cost_bearer?: CostBearer | null
+}
 
 export async function createPatient(
   _prevState: ActionResult<Tables<"patients">> | null,
@@ -36,7 +48,7 @@ export async function createPatient(
   const supabase = await createClient()
   const { data: patient, error } = await supabase
     .from("patients")
-    .insert(patientData)
+    .insert(patientData as PatientInsertPayload)
     .select()
     .single()
 
@@ -130,7 +142,9 @@ export async function updatePatient(
     .update(
       // Mark pending on address change so the backfill/cron can recover if the
       // fire-and-forget geocode below fails.
-      addressChanged ? { ...patientData, geocode_status: "pending" as const } : patientData
+      (addressChanged
+        ? { ...patientData, geocode_status: "pending" as const }
+        : patientData) as PatientUpdatePayload
     )
     .eq("id", id)
     .select()
@@ -213,7 +227,7 @@ export async function createPatientInline(
   const supabase = await createClient()
   const { data: patient, error } = await supabase
     .from("patients")
-    .insert(result.data)
+    .insert(result.data as PatientInsertPayload)
     .select()
     .single()
 

--- a/src/actions/quick-capture.ts
+++ b/src/actions/quick-capture.ts
@@ -6,6 +6,7 @@ import { createClient } from "@/lib/supabase/server"
 import { requireAuth } from "@/lib/auth/require-auth"
 import { logAudit } from "@/lib/audit/logger"
 import { trackEvent } from "@/lib/telemetry"
+import { rideRequirementsSchema } from "@/lib/validations/rides"
 import type { ActionResult } from "@/actions/shared"
 import type { Enums, Json } from "@/lib/types/database"
 
@@ -16,9 +17,13 @@ const quickCaptureSchema = z.object({
   pickup_time: z.string().min(1, "Abholzeit ist erforderlich"),
   direction: z.enum(["outbound", "return", "both"]),
   duration_category: z.enum(["under_2h", "over_2h"]).default("under_2h"),
+  // Transport requirements (Issue #126/#130) -- optional in quick capture.
+  requirements: rideRequirementsSchema,
 })
 
-export type QuickCaptureInput = z.infer<typeof quickCaptureSchema>
+// Use the *input* type so fields with defaults (duration_category,
+// requirements) stay optional for callers; parsed output fills the defaults.
+export type QuickCaptureInput = z.input<typeof quickCaptureSchema>
 
 /**
  * Quick-capture ride creation: minimal fields, no redirect.
@@ -41,8 +46,17 @@ export async function quickCreateRide(
     return { success: false, error: firstError }
   }
 
-  const { patient_id, destination_id, date, pickup_time, direction, duration_category } =
-    parsed.data
+  const {
+    patient_id,
+    destination_id,
+    date,
+    pickup_time,
+    direction,
+    duration_category,
+    requirements,
+  } = parsed.data
+  // A `companion` requirement always implies an escort (Issue #130).
+  const hasEscort = requirements.includes("companion")
   const supabase = await createClient()
 
   // Price calculation is best-effort for quick capture
@@ -55,8 +69,10 @@ export async function quickCreateRide(
     surcharge_amount?: number
     surcharge_details?: Json | null
     duration_category?: string
+    has_escort?: boolean
   } = {
     duration_category,
+    has_escort: hasEscort,
   }
 
   try {
@@ -95,7 +111,7 @@ export async function quickCreateRide(
         direction,
         durationCategory: duration_category,
         destinationName: dest.display_name,
-        hasEscort: false,
+        hasEscort,
         isTagesheimImwilOverride: false,
       })
 
@@ -129,6 +145,7 @@ export async function quickCreateRide(
         pickup_time,
         direction: "outbound" as Enums<"ride_direction">,
         status: "unplanned" as Enums<"ride_status">,
+        requirements,
         ...priceFields,
       })
       .select("id")
@@ -147,6 +164,8 @@ export async function quickCreateRide(
       direction: "return" as Enums<"ride_direction">,
       status: "unplanned" as Enums<"ride_status">,
       parent_ride_id: outboundRide.id,
+      requirements,
+      has_escort: hasEscort,
     })
 
     if (retError) {
@@ -178,6 +197,7 @@ export async function quickCreateRide(
         pickup_time,
         direction: direction as Enums<"ride_direction">,
         status: "unplanned" as Enums<"ride_status">,
+        requirements,
         ...priceFields,
       })
       .select("id")

--- a/src/actions/rides.ts
+++ b/src/actions/rides.ts
@@ -30,12 +30,40 @@ import {
 import type { DriverDayStatus } from "@/lib/availability/driver-status"
 import { trackEvent } from "@/lib/telemetry"
 import { uuidSchema } from "@/lib/validations/shared"
-import type { ActionResult } from "@/actions/shared"
+import { collectRideWarnings } from "@/lib/rides/warnings"
+import type { ActionResult, ActionWarning } from "@/actions/shared"
 import type { Tables, Enums, Json } from "@/lib/types/database"
+import type { RideRequirement } from "@/lib/rides/requirements"
 
 /** Shown when a driver is assigned while on an approved absence (Issue #104). */
 const DRIVER_ABSENT_ERROR =
   "Der gewaehlte Fahrer ist an diesem Datum abwesend (Ferien/Abwesenheit). Bitte einen anderen Fahrer waehlen."
+
+/**
+ * Parse ride form data through `rideSchema`.
+ *
+ * `requirements` is a multi-value field: `Object.fromEntries(formData)` keeps
+ * only the last value for repeated keys, so it is pulled out explicitly via
+ * `getAll` and merged back in before validation (Issue #126/#130).
+ */
+function parseRideForm(formData: FormData) {
+  const raw = Object.fromEntries(formData)
+  const requirements = formData.getAll("requirements").map(String)
+  return rideSchema.safeParse({ ...raw, requirements })
+}
+
+/**
+ * Ensure tariff/requirement consistency (Issue #130): a `companion` transport
+ * requirement always implies a hospital escort, so `has_escort` is forced true
+ * in that case. The mirror is intentionally one-directional to avoid double
+ * bookkeeping -- an escort surcharge does not add a `companion` requirement.
+ */
+function resolveHasEscort(
+  hasEscort: boolean,
+  requirements: readonly RideRequirement[]
+): boolean {
+  return hasEscort || requirements.includes("companion")
+}
 
 /** Inline Zod schema for series fields extracted from the ride form. */
 const seriesFieldsSchema = z.object({
@@ -68,11 +96,10 @@ export async function createRide(
 
   // Delegate to series creation if the series toggle is enabled
   if (formData.get("enable_series") === "true") {
-    return createRideWithSeries(formData, auth.userId)
+    return createRideWithSeries(formData, auth.userId, auth.role)
   }
 
-  const raw = Object.fromEntries(formData)
-  const result = rideSchema.safeParse(raw)
+  const result = parseRideForm(formData)
 
   if (!result.success) {
     return {
@@ -91,13 +118,23 @@ export async function createRide(
     duration_category,
     is_tagesheim_imwil,
     has_escort,
+    requirements,
     ...rideData
   } = result.data
+  // A `companion` requirement always implies an escort (Issue #130).
+  const effectiveHasEscort = resolveHasEscort(has_escort, requirements)
   const status: Enums<"ride_status"> = rideData.driver_id
     ? "planned"
     : "unplanned"
 
   const supabase = await createClient()
+
+  // Non-blocking warning trackers (Issue #130): default to "not resolved" so a
+  // thrown price/route calculation still yields correct warnings without ever
+  // blocking the save. A manual override already counts as a resolved price.
+  let patientGeocoded = false
+  let destinationGeocoded = false
+  let priceResolved = price_override != null
 
   // Availability / absence guard (Issue #104): block absent drivers, remember
   // whether the assignment lands outside the driver's availability window so we
@@ -133,7 +170,7 @@ export async function createRide(
   } = {
     duration_category,
     is_tagesheim_imwil,
-    has_escort,
+    has_escort: effectiveHasEscort,
   }
 
   // Include manual override if provided
@@ -160,6 +197,9 @@ export async function createRide(
     const patient = patientRes.data
     const dest = destRes.data
 
+    patientGeocoded = patient?.lat != null && patient?.lng != null
+    destinationGeocoded = dest?.lat != null && dest?.lng != null
+
     if (
       patient?.postal_code &&
       dest?.postal_code &&
@@ -179,11 +219,12 @@ export async function createRide(
         direction: rideData.direction,
         durationCategory: duration_category,
         destinationName: dest.display_name,
-        hasEscort: has_escort,
+        hasEscort: effectiveHasEscort,
         isTagesheimImwilOverride: is_tagesheim_imwil,
       })
 
       if (priceResult) {
+        priceResolved = priceResolved || priceResult.calculated_price != null
         priceFields = {
           ...priceFields,
           distance_meters: priceResult.distance_meters,
@@ -207,13 +248,23 @@ export async function createRide(
   // 1. Create the outbound ride
   const { data: outboundRide, error } = await supabase
     .from("rides")
-    .insert({ ...rideData, ...priceFields, status })
+    .insert({ ...rideData, ...priceFields, requirements, status })
     .select()
     .single()
 
   if (error) {
     return { success: false, error: error.message }
   }
+
+  // Collect non-blocking persistence warnings (Issue #130). Missing geo/route/
+  // price/appointment never blocks -- it is surfaced for the dispatcher instead.
+  const warnings = collectRideWarnings({
+    patientGeocoded,
+    destinationGeocoded,
+    priceResolved,
+    appointmentTimeSet:
+      rideData.direction === "return" || Boolean(rideData.appointment_time),
+  })
 
   // Telemetry: track ride creation
   trackEvent({
@@ -224,6 +275,9 @@ export async function createRide(
       direction: rideData.direction,
       has_driver: Boolean(rideData.driver_id),
       has_price: Boolean(priceFields.calculated_price),
+      requirements_count: requirements.length,
+      has_escort: effectiveHasEscort,
+      warning_codes: warnings.map((w) => w.code),
     },
   })
 
@@ -234,7 +288,13 @@ export async function createRide(
     action: "create",
     entityType: "ride",
     entityId: outboundRide.id,
-    metadata: { status, direction: rideData.direction },
+    metadata: {
+      status,
+      direction: rideData.direction,
+      requirements,
+      has_escort: effectiveHasEscort,
+      warning_codes: warnings.map((w) => w.code),
+    },
   }).catch(() => {})
 
   // Note out-of-availability assignment in the communication_log (Issue #104)
@@ -280,6 +340,12 @@ export async function createRide(
 
   revalidatePath("/rides")
   revalidatePath("/dispatch")
+
+  // Never-block: on warnings, return success + warnings so the form can surface
+  // them (#139) instead of navigating away. The clean path redirects as before.
+  if (warnings.length > 0) {
+    return { success: true, data: outboundRide, warnings }
+  }
   redirect(`/rides?date=${rideData.date}`)
 }
 
@@ -289,11 +355,11 @@ export async function createRide(
  */
 async function createRideWithSeries(
   formData: FormData,
-  authorId: string
+  authorId: string,
+  authorRole: string
 ): Promise<ActionResult<Tables<"rides">>> {
   // 1. Validate ride data
-  const raw = Object.fromEntries(formData)
-  const rideResult = rideSchema.safeParse(raw)
+  const rideResult = parseRideForm(formData)
 
   if (!rideResult.success) {
     return {
@@ -328,14 +394,21 @@ async function createRideWithSeries(
     duration_category,
     is_tagesheim_imwil,
     has_escort,
+    requirements,
     ...rideData
   } = rideResult.data
+  const effectiveHasEscort = resolveHasEscort(has_escort, requirements)
   const seriesData = seriesResult.data
   const status: Enums<"ride_status"> = rideData.driver_id
     ? "planned"
     : "unplanned"
 
   const supabase = await createClient()
+
+  // Non-blocking warning trackers for the initial ride (Issue #130).
+  let patientGeocoded = false
+  let destinationGeocoded = false
+  let priceResolved = price_override != null
 
   // Availability / absence guard for the initial ride's driver (Issue #104).
   let driverStatus: DriverDayStatus | null = null
@@ -399,7 +472,7 @@ async function createRideWithSeries(
   } = {
     duration_category,
     is_tagesheim_imwil,
-    has_escort,
+    has_escort: effectiveHasEscort,
   }
 
   if (price_override != null) {
@@ -424,6 +497,9 @@ async function createRideWithSeries(
     const patient = patientRes.data
     const dest = destRes.data
 
+    patientGeocoded = patient?.lat != null && patient?.lng != null
+    destinationGeocoded = dest?.lat != null && dest?.lng != null
+
     if (
       patient?.postal_code &&
       dest?.postal_code &&
@@ -443,11 +519,12 @@ async function createRideWithSeries(
         direction: rideData.direction,
         durationCategory: duration_category,
         destinationName: dest.display_name,
-        hasEscort: has_escort,
+        hasEscort: effectiveHasEscort,
         isTagesheimImwilOverride: is_tagesheim_imwil,
       })
 
       if (priceResult) {
+        priceResolved = priceResolved || priceResult.calculated_price != null
         priceFields = {
           ...priceFields,
           distance_meters: priceResult.distance_meters,
@@ -476,6 +553,7 @@ async function createRideWithSeries(
     .insert({
       ...rideData,
       ...priceFields,
+      requirements,
       status,
       ride_series_id: series.id,
     })
@@ -485,6 +563,46 @@ async function createRideWithSeries(
   if (rideError) {
     return { success: false, error: rideError.message }
   }
+
+  // Fire-and-forget audit + telemetry for the series' initial ride (Issue #130)
+  const warnings = collectRideWarnings({
+    patientGeocoded,
+    destinationGeocoded,
+    priceResolved,
+    appointmentTimeSet:
+      rideData.direction === "return" || Boolean(rideData.appointment_time),
+  })
+
+  trackEvent({
+    event: "ride_created",
+    userId: authorId,
+    properties: {
+      status,
+      direction: rideData.direction,
+      has_driver: Boolean(rideData.driver_id),
+      has_price: Boolean(priceFields.calculated_price),
+      requirements_count: requirements.length,
+      has_escort: effectiveHasEscort,
+      is_series: true,
+      warning_codes: warnings.map((w) => w.code),
+    },
+  })
+
+  logAudit({
+    userId: authorId,
+    userRole: authorRole,
+    action: "create",
+    entityType: "ride",
+    entityId: initialRide.id,
+    metadata: {
+      status,
+      direction: rideData.direction,
+      requirements,
+      has_escort: effectiveHasEscort,
+      ride_series_id: series.id,
+      warning_codes: warnings.map((w) => w.code),
+    },
+  }).catch(() => {})
 
   // Note out-of-availability assignment for the initial ride (Issue #104)
   if (rideData.driver_id && driverStatus && !driverStatus.isWithinAvailability) {
@@ -518,6 +636,7 @@ async function createRideWithSeries(
         status: "unplanned" as const,
         parent_ride_id: initialRide.id,
         ride_series_id: series.id,
+        requirements,
       })
 
       if (returnError) {
@@ -568,6 +687,7 @@ async function createRideWithSeries(
           status: "unplanned",
           appointment_time: rideData.appointment_time ?? null,
           appointment_end_time: rideData.appointment_end_time ?? null,
+          requirements,
         })
         .select("id")
         .single()
@@ -585,6 +705,7 @@ async function createRideWithSeries(
           status: "unplanned",
           parent_ride_id: outbound.id,
           return_pickup_time: rideData.return_pickup_time ?? null,
+          requirements,
         })
       }
     } else {
@@ -610,6 +731,7 @@ async function createRideWithSeries(
             dir === "outbound"
               ? (rideData.appointment_end_time ?? null)
               : null,
+          requirements,
         })
       }
     }
@@ -618,6 +740,11 @@ async function createRideWithSeries(
   revalidatePath("/rides")
   revalidatePath("/ride-series")
   revalidatePath("/dispatch")
+
+  // Never-block: surface warnings from the initial ride instead of redirecting.
+  if (warnings.length > 0) {
+    return { success: true, data: initialRide, warnings }
+  }
   redirect(`/rides?date=${rideData.date}`)
 }
 
@@ -633,8 +760,7 @@ export async function updateRide(
     return { success: false, error: auth.error }
   }
 
-  const raw = Object.fromEntries(formData)
-  const result = rideSchema.safeParse(raw)
+  const result = parseRideForm(formData)
 
   if (!result.success) {
     return {
@@ -654,10 +780,17 @@ export async function updateRide(
     duration_category,
     is_tagesheim_imwil,
     has_escort,
+    requirements,
     ...rideData
   } = result.data
+  const effectiveHasEscort = resolveHasEscort(has_escort, requirements)
 
   const supabase = await createClient()
+
+  // Non-blocking warning trackers (Issue #130).
+  let patientGeocoded = false
+  let destinationGeocoded = false
+  let priceResolved = price_override != null
 
   // Fetch current ride to check for auto-transition
   const { data: currentRide } = await supabase
@@ -710,7 +843,7 @@ export async function updateRide(
   } = {
     duration_category,
     is_tagesheim_imwil,
-    has_escort,
+    has_escort: effectiveHasEscort,
   }
 
   // Include manual override (or clear it if not provided)
@@ -735,6 +868,9 @@ export async function updateRide(
     const patient = patientRes.data
     const dest = destRes.data
 
+    patientGeocoded = patient?.lat != null && patient?.lng != null
+    destinationGeocoded = dest?.lat != null && dest?.lng != null
+
     if (
       patient?.postal_code &&
       dest?.postal_code &&
@@ -754,11 +890,12 @@ export async function updateRide(
         direction: rideData.direction,
         durationCategory: duration_category,
         destinationName: dest.display_name,
-        hasEscort: has_escort,
+        hasEscort: effectiveHasEscort,
         isTagesheimImwilOverride: is_tagesheim_imwil,
       })
 
       if (priceResult) {
+        priceResolved = priceResolved || priceResult.calculated_price != null
         priceFields = {
           ...priceFields,
           distance_meters: priceResult.distance_meters,
@@ -783,6 +920,7 @@ export async function updateRide(
   const updateData: Record<string, unknown> = {
     ...rideData,
     ...priceFields,
+    requirements,
   }
   if (
     currentRide.status === "unplanned" &&
@@ -803,6 +941,15 @@ export async function updateRide(
     return { success: false, error: error.message }
   }
 
+  // Collect non-blocking persistence warnings (Issue #130).
+  const warnings = collectRideWarnings({
+    patientGeocoded,
+    destinationGeocoded,
+    priceResolved,
+    appointmentTimeSet:
+      rideData.direction === "return" || Boolean(rideData.appointment_time),
+  })
+
   // Fire-and-forget audit log
   logAudit({
     userId: auth.userId,
@@ -810,8 +957,25 @@ export async function updateRide(
     action: "update",
     entityType: "ride",
     entityId: id,
-    metadata: { fields: Object.keys(rideData) },
+    metadata: {
+      fields: [...Object.keys(rideData), "requirements"],
+      requirements,
+      has_escort: effectiveHasEscort,
+      warning_codes: warnings.map((w) => w.code),
+    },
   }).catch(() => {})
+
+  // Telemetry: track ride update (Issue #130)
+  trackEvent({
+    event: "ride_updated",
+    userId: auth.userId,
+    properties: {
+      has_price: Boolean(priceFields.calculated_price),
+      requirements_count: requirements.length,
+      has_escort: effectiveHasEscort,
+      warning_codes: warnings.map((w) => w.code),
+    },
+  })
 
   // Note out-of-availability assignment in the communication_log (Issue #104)
   if (rideData.driver_id && driverStatus && !driverStatus.isWithinAvailability) {
@@ -825,6 +989,11 @@ export async function updateRide(
 
   revalidatePath("/rides")
   revalidatePath("/dispatch")
+
+  // Never-block: surface warnings instead of redirecting when present.
+  if (warnings.length > 0) {
+    return { success: true, data, warnings }
+  }
   redirect(`/rides?date=${rideData.date}`)
 }
 

--- a/src/actions/rides.ts
+++ b/src/actions/rides.ts
@@ -8,8 +8,8 @@ import { requireAuth } from "@/lib/auth/require-auth"
 import {
   rideSchema,
   addMinutesToTime,
-  DEFAULT_RETURN_BUFFER_MINUTES,
 } from "@/lib/validations/rides"
+import { loadRideTimeBuffers } from "@/lib/rides/time-buffers"
 import { assertTransitionForRole } from "@/lib/rides/status-machine"
 import { invalidateTokensForRide } from "@/lib/mail/tokens"
 import { sendDriverNotification } from "@/lib/mail/send-driver-notification"
@@ -249,12 +249,13 @@ export async function createRide(
 
   // 2. Optionally create return ride
   if (create_return_ride && rideData.direction === "outbound") {
+    const { returnBufferMinutes } = await loadRideTimeBuffers(supabase)
     const returnPickupTime =
       rideData.return_pickup_time ??
       (rideData.appointment_end_time
         ? addMinutesToTime(
             rideData.appointment_end_time,
-            DEFAULT_RETURN_BUFFER_MINUTES
+            returnBufferMinutes
           )
         : null)
 
@@ -497,12 +498,13 @@ async function createRideWithSeries(
 
   // 6. Optionally create return ride for the initial date
   if (create_return_ride && rideData.direction === "outbound") {
+    const { returnBufferMinutes } = await loadRideTimeBuffers(supabase)
     const returnPickupTime =
       rideData.return_pickup_time ??
       (rideData.appointment_end_time
         ? addMinutesToTime(
             rideData.appointment_end_time,
-            DEFAULT_RETURN_BUFFER_MINUTES
+            returnBufferMinutes
           )
         : null)
 

--- a/src/actions/rides.ts
+++ b/src/actions/rides.ts
@@ -343,7 +343,11 @@ export async function createRide(
 
   // Never-block: on warnings, return success + warnings so the form can surface
   // them (#139) instead of navigating away. The clean path redirects as before.
-  if (warnings.length > 0) {
+  // "+ Auftragsblatt" (#139): save_intent=order_sheet skips the redirect too,
+  // so the capture form can open the M11 order sheet for the newly created ride.
+  const skipRedirect =
+    warnings.length > 0 || formData.get("save_intent") === "order_sheet"
+  if (skipRedirect) {
     return { success: true, data: outboundRide, warnings }
   }
   redirect(`/rides?date=${rideData.date}`)
@@ -742,7 +746,11 @@ async function createRideWithSeries(
   revalidatePath("/dispatch")
 
   // Never-block: surface warnings from the initial ride instead of redirecting.
-  if (warnings.length > 0) {
+  // "+ Auftragsblatt" (#139): skip the redirect on save_intent=order_sheet as in
+  // createRide, so the order sheet can be opened for the series' initial ride.
+  const skipRedirect =
+    warnings.length > 0 || formData.get("save_intent") === "order_sheet"
+  if (skipRedirect) {
     return { success: true, data: initialRide, warnings }
   }
   redirect(`/rides?date=${rideData.date}`)

--- a/src/actions/shared.ts
+++ b/src/actions/shared.ts
@@ -1,3 +1,21 @@
+/**
+ * A non-blocking warning attached to a successful action result.
+ *
+ * Warnings communicate soft problems (e.g. missing geocoding, price that could
+ * not be calculated) that MUST NOT prevent the operation from succeeding. The
+ * `code` is a stable, whitelisted machine identifier the UI (#139) can map to
+ * localized copy or decide to suppress; `message` is a ready-to-render German
+ * fallback.
+ */
+export interface ActionWarning {
+  /** Stable machine code (whitelisted) for the UI to map/suppress (#139). */
+  code: string
+  /** Human-readable German fallback message. */
+  message: string
+  /** Optional related form field, mirroring `fieldErrors` keys. */
+  field?: string
+}
+
 export type ActionResult<T = void> =
-  | { success: true; data: T }
+  | { success: true; data: T; warnings?: ActionWarning[] }
   | { success: false; error?: string; fieldErrors?: Record<string, string[]> }

--- a/src/app/(dashboard)/rides/erfassen/loading.tsx
+++ b/src/app/(dashboard)/rides/erfassen/loading.tsx
@@ -1,0 +1,29 @@
+export default function ErfassenLoading() {
+  return (
+    <div className="space-y-6">
+      {/* Page header skeleton */}
+      <div className="glass-panel space-y-3 rounded-2xl p-5 sm:p-6">
+        <div className="h-5 w-32 animate-pulse rounded bg-muted" />
+        <div className="h-7 w-48 animate-pulse rounded bg-muted" />
+      </div>
+
+      {/* Two-column skeleton */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_minmax(360px,440px)] lg:items-start">
+        <div className="space-y-6">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="space-y-4 rounded-xl border p-6">
+              <div className="h-5 w-40 animate-pulse rounded bg-muted" />
+              <div className="h-11 w-full animate-pulse rounded bg-muted" />
+              <div className="h-11 w-full animate-pulse rounded bg-muted" />
+            </div>
+          ))}
+        </div>
+        <div className="space-y-4">
+          <div className="h-48 w-full animate-pulse rounded-xl bg-muted" />
+          <div className="h-40 w-full animate-pulse rounded-xl bg-muted" />
+          <div className="h-24 w-full animate-pulse rounded-xl bg-muted" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/rides/erfassen/page.tsx
+++ b/src/app/(dashboard)/rides/erfassen/page.tsx
@@ -1,0 +1,69 @@
+import type { Metadata } from "next"
+import { redirect } from "next/navigation"
+import { createClient } from "@/lib/supabase/server"
+import { requireAuth } from "@/lib/auth/require-auth"
+import { PageHeader } from "@/components/dashboard/page-header"
+import { RideCaptureForm } from "@/components/rides/ride-capture-form"
+import { loadRideTimeBuffers } from "@/lib/rides/time-buffers"
+import type {
+  CapturePatient,
+  CaptureDestination,
+} from "@/components/rides/capture/types"
+
+export const metadata: Metadata = {
+  title: "Fahrt erfassen - Dispo",
+}
+
+interface ErfassenPageProps {
+  searchParams: Promise<{
+    date?: string
+    patient_id?: string
+    destination_id?: string
+  }>
+}
+
+export default async function ErfassenPage({ searchParams }: ErfassenPageProps) {
+  const auth = await requireAuth(["admin", "operator"])
+  if (!auth.authorized) {
+    redirect("/login")
+  }
+
+  const { date, patient_id, destination_id } = await searchParams
+  const supabase = await createClient()
+
+  const [patientsRes, destinationsRes, timeBuffers] = await Promise.all([
+    supabase
+      .from("patients")
+      .select("id, first_name, last_name, cost_bearer")
+      .eq("is_active", true)
+      .order("last_name"),
+    supabase
+      .from("destinations")
+      .select("id, display_name, postal_code")
+      .eq("is_active", true)
+      .order("display_name"),
+    loadRideTimeBuffers(supabase),
+  ])
+
+  const patients: CapturePatient[] = patientsRes.data ?? []
+  const destinations: CaptureDestination[] = destinationsRes.data ?? []
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Fahrt erfassen"
+        description="Wer → wohin & wann → Fahrt. Ergebnis rechts live."
+        backHref="/rides"
+        backLabel="Zu den Fahrten"
+      />
+      <RideCaptureForm
+        patients={patients}
+        destinations={destinations}
+        timeBuffers={timeBuffers}
+        defaultDate={date}
+        defaultPatientId={patient_id}
+        defaultDestinationId={destination_id}
+      />
+    </div>
+  )
+}

--- a/src/app/(dashboard)/rides/page.tsx
+++ b/src/app/(dashboard)/rides/page.tsx
@@ -74,6 +74,15 @@ export default async function RidesPage({ searchParams }: RidesPageProps) {
           description="Tagesuebersicht"
           createHref={isStaff ? `/rides/new?date=${selectedDate}` : undefined}
           createLabel="Neue Fahrt"
+          actions={
+            isStaff ? (
+              <Button variant="outline" asChild>
+                <Link href={`/rides/erfassen?date=${selectedDate}`}>
+                  Fahrt erfassen
+                </Link>
+              </Button>
+            ) : undefined
+          }
         />
 
         {driverFilterName && (
@@ -169,6 +178,13 @@ export default async function RidesPage({ searchParams }: RidesPageProps) {
         description="Wochenuebersicht"
         createHref={isStaff ? "/rides/new" : undefined}
         createLabel="Neue Fahrt"
+        actions={
+          isStaff ? (
+            <Button variant="outline" asChild>
+              <Link href="/rides/erfassen">Fahrt erfassen</Link>
+            </Button>
+          ) : undefined
+        }
       />
 
       {driverFilterName && (

--- a/src/app/api/mail/preview/route.ts
+++ b/src/app/api/mail/preview/route.ts
@@ -51,14 +51,9 @@ export async function GET(request: Request) {
     )
   }
 
-  if (!ride.driver_id) {
-    return NextResponse.json(
-      { error: "No driver assigned to this ride" },
-      { status: 404 }
-    )
-  }
-
-  // Load full order sheet data (uses admin client internally)
+  // Load full order sheet data (uses admin client internally). driver_id may be
+  // null for unplanned rides captured via the one-page dispo (#139) — the order
+  // sheet then renders a "no driver assigned yet" placeholder.
   try {
     const data = await loadOrderSheetData(rideId, ride.driver_id, "#", "#")
     let html = assembleOrderSheet(data)

--- a/src/components/patients/patient-detail-sheet.tsx
+++ b/src/components/patients/patient-detail-sheet.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { MapPin, Phone, ShieldAlert, MessageSquare, StickyNote, Plus } from "lucide-react"
+import { MapPin, Phone, ShieldAlert, MessageSquare, StickyNote, Plus, Wallet } from "lucide-react"
 import {
   Sheet,
   SheetContent,
@@ -18,6 +18,7 @@ import { DeactivateDialog } from "@/components/shared/deactivate-dialog"
 import { AnonymizeDialog } from "@/components/shared/anonymize-dialog"
 import { anonymizePatient } from "@/actions/gdpr"
 import type { Tables, Enums } from "@/lib/types/database"
+import { COST_BEARER_LABELS, type PatientWithCostBearer } from "@/lib/patients/constants"
 
 const IMPAIRMENT_LABELS: Record<string, string> = {
   rollator: "Rollator",
@@ -65,6 +66,11 @@ export function PatientDetailSheet({
   const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
   const hasCoords = patient.lat != null && patient.lng != null && apiKey
 
+  // #125: cost_bearer is not yet in the generated patient type — read via a
+  // documented cast (through unknown, since the current row type omits the
+  // column). Remove once database.ts is regenerated.
+  const costBearer = (patient as unknown as PatientWithCostBearer).cost_bearer
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent className="sm:max-w-[480px] flex flex-col">
@@ -100,6 +106,17 @@ export function PatientDetailSheet({
             <div className="flex items-start gap-2 text-sm">
               <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
               <span>{address}</span>
+            </div>
+          )}
+
+          {/* Cost bearer */}
+          {costBearer && (
+            <div className="flex items-center gap-2 text-sm">
+              <Wallet className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span>
+                <span className="text-muted-foreground">Kostenträger: </span>
+                {COST_BEARER_LABELS[costBearer]}
+              </span>
             </div>
           )}
 

--- a/src/components/patients/patient-form.tsx
+++ b/src/components/patients/patient-form.tsx
@@ -7,6 +7,13 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { SubmitButton } from "@/components/shared/submit-button"
@@ -15,6 +22,12 @@ import { LocationMap } from "@/components/shared/location-map"
 import { PlacesAutocomplete, type PlaceSelectResult } from "@/components/shared/places-autocomplete"
 import { createPatient, updatePatient } from "@/actions/patients"
 import type { Tables } from "@/lib/types/database"
+import {
+  COST_BEARER_VALUES,
+  COST_BEARER_LABELS,
+  COST_BEARER_NONE,
+  type PatientWithCostBearer,
+} from "@/lib/patients/constants"
 
 const IMPAIRMENT_OPTIONS = [
   { value: "rollator", label: "Rollator" },
@@ -53,6 +66,10 @@ export function PatientForm({ patient }: PatientFormProps) {
     useState<string[]>(initialImpairments)
 
   const fieldErrors = state && !state.success ? state.fieldErrors : undefined
+
+  // #125: cost_bearer is not yet in the generated patient type — read via cast.
+  const costBearerDefault =
+    (patient as PatientWithCostBearer | undefined)?.cost_bearer ?? COST_BEARER_NONE
 
   function toggleImpairment(value: string, checked: boolean) {
     setCheckedImpairments((prev) =>
@@ -132,6 +149,30 @@ export function PatientForm({ patient }: PatientFormProps) {
             {fieldErrors?.phone && (
               <p className="text-sm text-destructive">
                 {fieldErrors.phone[0]}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="cost_bearer">Kostenträger</Label>
+            <Select name="cost_bearer" defaultValue={costBearerDefault}>
+              <SelectTrigger id="cost_bearer">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={COST_BEARER_NONE}>
+                  Nicht angegeben
+                </SelectItem>
+                {COST_BEARER_VALUES.map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {COST_BEARER_LABELS[value]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {fieldErrors?.cost_bearer && (
+              <p className="text-sm text-destructive">
+                {fieldErrors.cost_bearer[0]}
               </p>
             )}
           </div>

--- a/src/components/patients/patient-inline-dialog.tsx
+++ b/src/components/patients/patient-inline-dialog.tsx
@@ -5,6 +5,13 @@ import { useFormState } from "react-dom"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -17,6 +24,11 @@ import { SubmitButton } from "@/components/shared/submit-button"
 import { AddressFields } from "@/components/shared/address-fields"
 import { createPatientInline } from "@/actions/patients"
 import type { Tables } from "@/lib/types/database"
+import {
+  COST_BEARER_VALUES,
+  COST_BEARER_LABELS,
+  COST_BEARER_NONE,
+} from "@/lib/patients/constants"
 
 interface PatientInlineDialogProps {
   open: boolean
@@ -114,6 +126,30 @@ export function PatientInlineDialog({
               }
               required
             />
+
+            <div className="space-y-2">
+              <Label htmlFor="inline_patient_cost_bearer">Kostenträger</Label>
+              <Select name="cost_bearer" defaultValue={COST_BEARER_NONE}>
+                <SelectTrigger id="inline_patient_cost_bearer">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={COST_BEARER_NONE}>
+                    Nicht angegeben
+                  </SelectItem>
+                  {COST_BEARER_VALUES.map((value) => (
+                    <SelectItem key={value} value={value}>
+                      {COST_BEARER_LABELS[value]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {state && !state.success && state.fieldErrors?.cost_bearer && (
+                <p className="text-sm text-destructive">
+                  {state.fieldErrors.cost_bearer[0]}
+                </p>
+              )}
+            </div>
 
             <DialogFooter>
               <Button

--- a/src/components/rides/capture/capture-destination-field.tsx
+++ b/src/components/rides/capture/capture-destination-field.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+// SLOT (#134): Ziel-Such-/Auswahlfeld + Inline-"＋ neu"-Anlage.
+// Functional stub reusing EntityCombobox (see capture-patient-field for the same
+// pattern). Issue #134 owns the inline create dialog and richer result rendering
+// (facility type, geocode status). Keep the props contract and the
+// `name="destination_id"` hidden input stable.
+
+import { useMemo } from "react"
+import { EntityCombobox } from "@/components/shared/entity-combobox"
+import type { CaptureDestination } from "./types"
+
+export interface CaptureDestinationFieldProps {
+  /** Selectable destinations (kept in the core for inline-created ones). */
+  destinations: CaptureDestination[]
+  /** Currently selected destination id, or null. */
+  value: string | null
+  /** Selection change handler. */
+  onChange: (id: string | null) => void
+  /** SLOT (#134): open the inline "neues Ziel" dialog. */
+  onCreateNew?: () => void
+  /** Field-level validation error from the server action. */
+  error?: string
+}
+
+export function CaptureDestinationField({
+  destinations,
+  value,
+  onChange,
+  onCreateNew,
+  error,
+}: CaptureDestinationFieldProps) {
+  const items = useMemo(
+    () =>
+      destinations.map((d) => ({
+        id: d.id,
+        label: d.display_name,
+        sublabel: d.postal_code ?? undefined,
+      })),
+    [destinations]
+  )
+
+  return (
+    <div className="space-y-1.5">
+      <EntityCombobox
+        items={items}
+        value={value}
+        onChange={onChange}
+        name="destination_id"
+        placeholder="Ziel suchen…"
+        emptyMessage="Kein Ziel gefunden"
+        aria-label="Ziel auswählen"
+        onCreateNew={onCreateNew}
+      />
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  )
+}

--- a/src/components/rides/capture/capture-destination-field.tsx
+++ b/src/components/rides/capture/capture-destination-field.tsx
@@ -1,13 +1,15 @@
 "use client"
 
-// SLOT (#134): Ziel-Such-/Auswahlfeld + Inline-"＋ neu"-Anlage.
-// Functional stub reusing EntityCombobox (see capture-patient-field for the same
-// pattern). Issue #134 owns the inline create dialog and richer result rendering
-// (facility type, geocode status). Keep the props contract and the
-// `name="destination_id"` hidden input stable.
+// Destination search/select field + inline "＋ neu anlegen" flow (#134).
+// Same pattern as capture-patient-field: reuses the shared EntityCombobox and
+// the existing DestinationInlineDialog (with fire-and-forget geocoding). The
+// dialog is owned here; on creation we hand the new destination up via
+// `onCreateNew` so the core appends it + selects it, triggering the route/price
+// recalculation. Keep the `name="destination_id"` hidden input stable.
 
-import { useMemo } from "react"
+import { useMemo, useState, useCallback } from "react"
 import { EntityCombobox } from "@/components/shared/entity-combobox"
+import { DestinationInlineDialog } from "@/components/destinations/destination-inline-dialog"
 import type { CaptureDestination } from "./types"
 
 export interface CaptureDestinationFieldProps {
@@ -17,8 +19,12 @@ export interface CaptureDestinationFieldProps {
   value: string | null
   /** Selection change handler. */
   onChange: (id: string | null) => void
-  /** SLOT (#134): open the inline "neues Ziel" dialog. */
-  onCreateNew?: () => void
+  /**
+   * Called with the inline-created destination. The core appends it to its
+   * destination list and selects it. When omitted, the "＋ Neu anlegen" action
+   * is hidden.
+   */
+  onCreateNew?: (destination: CaptureDestination) => void
   /** Field-level validation error from the server action. */
   error?: string
 }
@@ -30,6 +36,8 @@ export function CaptureDestinationField({
   onCreateNew,
   error,
 }: CaptureDestinationFieldProps) {
+  const [dialogOpen, setDialogOpen] = useState(false)
+
   const items = useMemo(
     () =>
       destinations.map((d) => ({
@@ -38,6 +46,21 @@ export function CaptureDestinationField({
         sublabel: d.postal_code ?? undefined,
       })),
     [destinations]
+  )
+
+  const handleCreated = useCallback(
+    (destination: { id: string; display_name: string }) => {
+      // The inline dialog forwards only id + display_name; postal_code is not
+      // part of its callback contract, so it defaults to null here (matches the
+      // edit-flow ride-form). Zone/price re-hydrate on the next reload; missing
+      // coordinates never block (best-effort geocoding, warned in D1).
+      onCreateNew?.({
+        id: destination.id,
+        display_name: destination.display_name,
+        postal_code: null,
+      })
+    },
+    [onCreateNew]
   )
 
   return (
@@ -50,9 +73,16 @@ export function CaptureDestinationField({
         placeholder="Ziel suchen…"
         emptyMessage="Kein Ziel gefunden"
         aria-label="Ziel auswählen"
-        onCreateNew={onCreateNew}
+        onCreateNew={onCreateNew ? () => setDialogOpen(true) : undefined}
       />
       {error && <p className="text-sm text-destructive">{error}</p>}
+      {onCreateNew && (
+        <DestinationInlineDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          onDestinationCreated={handleCreated}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/rides/capture/capture-patient-field.tsx
+++ b/src/components/rides/capture/capture-patient-field.tsx
@@ -1,14 +1,16 @@
 "use client"
 
-// SLOT (#134): Patient-Such-/Auswahlfeld + Inline-"＋ neu"-Anlage.
-// This functional stub already reuses the shared EntityCombobox so the capture
-// page is usable today. Issue #134 owns the inline create flow (wire the
-// `onCreateNew` dialog + append the created patient to the list) and any richer
-// result rendering (address preview, geocode status). Keep the props contract
-// and the `name="patient_id"` hidden input stable so the core keeps submitting.
+// Patient search/select field + inline "＋ neu anlegen" flow (#134).
+// Reuses the shared EntityCombobox for search and the existing
+// PatientInlineDialog (which since #125 also captures cost_bearer) for the
+// quick-create. The dialog is owned here; on creation we hand the new patient
+// up via `onCreateNew` so the core appends it to its list AND selects it, which
+// in turn triggers the route/price recalculation. Keep the `name="patient_id"`
+// hidden input (inside EntityCombobox) stable so the core keeps submitting.
 
-import { useMemo } from "react"
+import { useMemo, useState, useCallback } from "react"
 import { EntityCombobox } from "@/components/shared/entity-combobox"
+import { PatientInlineDialog } from "@/components/patients/patient-inline-dialog"
 import type { CapturePatient } from "./types"
 
 export interface CapturePatientFieldProps {
@@ -18,8 +20,11 @@ export interface CapturePatientFieldProps {
   value: string | null
   /** Selection change handler. */
   onChange: (id: string | null) => void
-  /** SLOT (#134): open the inline "neuer Patient" dialog. */
-  onCreateNew?: () => void
+  /**
+   * Called with the inline-created patient. The core appends it to its patient
+   * list and selects it. When omitted, the "＋ Neu anlegen" action is hidden.
+   */
+  onCreateNew?: (patient: CapturePatient) => void
   /** Field-level validation error from the server action. */
   error?: string
   /** Auto-focus on mount (first field in the phone-call flow). */
@@ -34,6 +39,8 @@ export function CapturePatientField({
   error,
   autoFocus = false,
 }: CapturePatientFieldProps) {
+  const [dialogOpen, setDialogOpen] = useState(false)
+
   const items = useMemo(
     () =>
       patients.map((p) => ({
@@ -41,6 +48,21 @@ export function CapturePatientField({
         label: `${p.last_name}, ${p.first_name}`,
       })),
     [patients]
+  )
+
+  const handleCreated = useCallback(
+    (patient: { id: string; first_name: string; last_name: string }) => {
+      // The inline dialog forwards only id + name; cost_bearer is not part of
+      // its callback contract, so it defaults to null here. The value is
+      // re-hydrated on the next reload (createPatientInline revalidates).
+      onCreateNew?.({
+        id: patient.id,
+        first_name: patient.first_name,
+        last_name: patient.last_name,
+        cost_bearer: null,
+      })
+    },
+    [onCreateNew]
   )
 
   return (
@@ -54,9 +76,16 @@ export function CapturePatientField({
         emptyMessage="Kein Patient gefunden"
         autoFocus={autoFocus}
         aria-label="Patient auswählen"
-        onCreateNew={onCreateNew}
+        onCreateNew={onCreateNew ? () => setDialogOpen(true) : undefined}
       />
       {error && <p className="text-sm text-destructive">{error}</p>}
+      {onCreateNew && (
+        <PatientInlineDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          onPatientCreated={handleCreated}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/rides/capture/capture-patient-field.tsx
+++ b/src/components/rides/capture/capture-patient-field.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+// SLOT (#134): Patient-Such-/Auswahlfeld + Inline-"＋ neu"-Anlage.
+// This functional stub already reuses the shared EntityCombobox so the capture
+// page is usable today. Issue #134 owns the inline create flow (wire the
+// `onCreateNew` dialog + append the created patient to the list) and any richer
+// result rendering (address preview, geocode status). Keep the props contract
+// and the `name="patient_id"` hidden input stable so the core keeps submitting.
+
+import { useMemo } from "react"
+import { EntityCombobox } from "@/components/shared/entity-combobox"
+import type { CapturePatient } from "./types"
+
+export interface CapturePatientFieldProps {
+  /** Selectable patients (kept in the core so inline-created ones can be added). */
+  patients: CapturePatient[]
+  /** Currently selected patient id, or null. */
+  value: string | null
+  /** Selection change handler. */
+  onChange: (id: string | null) => void
+  /** SLOT (#134): open the inline "neuer Patient" dialog. */
+  onCreateNew?: () => void
+  /** Field-level validation error from the server action. */
+  error?: string
+  /** Auto-focus on mount (first field in the phone-call flow). */
+  autoFocus?: boolean
+}
+
+export function CapturePatientField({
+  patients,
+  value,
+  onChange,
+  onCreateNew,
+  error,
+  autoFocus = false,
+}: CapturePatientFieldProps) {
+  const items = useMemo(
+    () =>
+      patients.map((p) => ({
+        id: p.id,
+        label: `${p.last_name}, ${p.first_name}`,
+      })),
+    [patients]
+  )
+
+  return (
+    <div className="space-y-1.5">
+      <EntityCombobox
+        items={items}
+        value={value}
+        onChange={onChange}
+        name="patient_id"
+        placeholder="Patient suchen…"
+        emptyMessage="Kein Patient gefunden"
+        autoFocus={autoFocus}
+        aria-label="Patient auswählen"
+        onCreateNew={onCreateNew}
+      />
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  )
+}

--- a/src/components/rides/capture/capture-save-actions.tsx
+++ b/src/components/rides/capture/capture-save-actions.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+/**
+ * CaptureSaveActions — the two save buttons of the ride capture page (#139).
+ *
+ * Both are real submit buttons of the same form; they only differ by the
+ * `save_intent` value carried into the FormData via the submitter:
+ *   - "Speichern & zur Übersicht"  → save_intent=list       (primary)
+ *   - "+ Auftragsblatt"            → save_intent=order_sheet (secondary)
+ *
+ * `createRide` (#130) redirects to the day view on the clean `list` path and
+ * skips the redirect for `order_sheet` (or whenever warnings exist), so the
+ * capture form can then show the post-save panel / open the M11 order sheet.
+ *
+ * Lives in its own component so `useFormStatus` reflects the parent form's
+ * pending state (the hook must run inside the <form>, not in the form itself).
+ */
+
+import Link from "next/link"
+import { useFormStatus } from "react-dom"
+import { Loader2, FileText } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export function CaptureSaveActions() {
+  const { pending } = useFormStatus()
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <Button
+          type="submit"
+          name="save_intent"
+          value="list"
+          disabled={pending}
+          aria-busy={pending}
+          className="flex-1"
+        >
+          {pending && (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+          )}
+          {pending ? "Speichern..." : "Speichern & zur Übersicht"}
+        </Button>
+        <Button
+          type="submit"
+          name="save_intent"
+          value="order_sheet"
+          variant="outline"
+          disabled={pending}
+          aria-busy={pending}
+          className="flex-1"
+        >
+          <FileText className="mr-2 h-4 w-4" aria-hidden="true" />
+          Auftragsblatt
+        </Button>
+      </div>
+      <Button variant="ghost" asChild className="w-full">
+        <Link href="/rides">Abbrechen</Link>
+      </Button>
+    </div>
+  )
+}

--- a/src/components/rides/capture/cost-bearer-display.tsx
+++ b/src/components/rides/capture/cost-bearer-display.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+// SLOT (#137): Kostenträger-Anzeige des gewählten Patienten.
+// Functional stub: shows the patient's cost bearer as a small badge (read-only
+// context for the dispatcher). Issue #137 can enrich this (e.g. billing hints,
+// warnings for self-payers). Keep the props contract stable.
+
+import { Wallet } from "lucide-react"
+import { COST_BEARER_LABELS } from "@/lib/patients/constants"
+import type { CapturePatient } from "./types"
+
+export interface CostBearerDisplayProps {
+  /** Currently selected patient, or null when none is chosen. */
+  patient: CapturePatient | null
+}
+
+export function CostBearerDisplay({ patient }: CostBearerDisplayProps) {
+  if (!patient) return null
+
+  const label = patient.cost_bearer
+    ? COST_BEARER_LABELS[patient.cost_bearer]
+    : "Kein Kostenträger hinterlegt"
+
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <Wallet className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      <span>
+        Kostenträger:{" "}
+        <span className={patient.cost_bearer ? "font-medium text-foreground" : ""}>
+          {label}
+        </span>
+      </span>
+    </div>
+  )
+}

--- a/src/components/rides/capture/cost-bearer-display.tsx
+++ b/src/components/rides/capture/cost-bearer-display.tsx
@@ -1,9 +1,17 @@
 "use client"
 
-// SLOT (#137): Kostenträger-Anzeige des gewählten Patienten.
-// Functional stub: shows the patient's cost bearer as a small badge (read-only
-// context for the dispatcher). Issue #137 can enrich this (e.g. billing hints,
-// warnings for self-payers). Keep the props contract stable.
+// SLOT (#137): Kostenträger-Anzeige des gewählten Patienten (READ-ONLY).
+//
+// Der Kostenträger liegt ausschließlich am Patienten (#125). Auf der
+// Erfassungsseite wird er nur ANGEZEIGT — es gibt KEIN Per-Fahrt-Select und
+// KEINE Persistenz auf `rides`. Editiert wird der Kostenträger ausschließlich
+// über die Patienten-Inline-Anlage/-Bearbeitung (#134); die Anzeige hier
+// aktualisiert sich automatisch, sobald ein (anderer) Patient gewählt wird,
+// da der Kern `patient` neu hereingibt.
+//
+// PII/Security: Kostenträger ist sensibel. Diese Seite ist staff-only
+// (admin/operator, via requireAuth im Server Action / Page-Guard) — hier ist
+// kein Fahrer-Sichtbarkeits-Thema. Nicht an Fahrer-/Auftragsblatt-Kopien ausgeben.
 
 import { Wallet } from "lucide-react"
 import { COST_BEARER_LABELS } from "@/lib/patients/constants"
@@ -15,20 +23,36 @@ export interface CostBearerDisplayProps {
 }
 
 export function CostBearerDisplay({ patient }: CostBearerDisplayProps) {
+  // No patient selected yet → nothing to show (no cost-bearer context).
   if (!patient) return null
 
-  const label = patient.cost_bearer
-    ? COST_BEARER_LABELS[patient.cost_bearer]
-    : "Kein Kostenträger hinterlegt"
+  // Narrow on the value directly so the index access stays non-null.
+  const bearer = patient.cost_bearer
+  const isSet = bearer !== null
+  const label = bearer ? COST_BEARER_LABELS[bearer] : "nicht gesetzt"
 
   return (
-    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-      <Wallet className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-      <span>
-        Kostenträger:{" "}
-        <span className={patient.cost_bearer ? "font-medium text-foreground" : ""}>
+    <div className="flex items-center gap-2 rounded-lg border bg-muted/30 px-3 py-2.5">
+      <Wallet
+        className="h-4 w-4 shrink-0 text-muted-foreground"
+        aria-hidden="true"
+      />
+      <div className="flex flex-1 flex-wrap items-baseline gap-x-2 gap-y-0.5">
+        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Kostenträger
+        </span>
+        <span
+          className={
+            isSet
+              ? "text-sm font-medium text-foreground"
+              : "text-sm italic text-muted-foreground"
+          }
+        >
           {label}
         </span>
+      </div>
+      <span className="shrink-0 text-[11px] text-muted-foreground">
+        über Patient pflegen
       </span>
     </div>
   )

--- a/src/components/rides/capture/requirement-chips.tsx
+++ b/src/components/rides/capture/requirement-chips.tsx
@@ -1,13 +1,35 @@
 "use client"
 
-// SLOT (#135): Bedarfs-Chips (Rollstuhl, Rollator, Begleitung, Sauerstoff, …).
-// Functional stub: renders a labeled placeholder and mirrors the current value
-// into hidden `requirements` inputs so form submission already carries them.
-// Issue #135 builds the toggleable chip UI (multi-select) on top of the same
-// props contract — the core owns the `value`/`onChange` state.
+// SLOT (#135): Bedarfs-Chips für die Fahrt-Erfassung.
+//
+// Tap-/klickbare Toggle-Chips für alle `RIDE_REQUIREMENTS` (Rollstuhl, Rollator,
+// Begleitung, Sauerstoff, Tragestuhl, Liegend). Der Kern besitzt den State und
+// gibt `value`/`onChange` herein — dieser Slot rendert nur die UI und spiegelt
+// die aktuelle Auswahl in versteckte Formularfelder:
+//   - `requirements` (multi-value, via formData.getAll) → rides.requirements (#126)
+//   - `has_escort` = "true", sobald "Begleitung" gewählt ist. Der Server koppelt
+//     das ohnehin über `resolveHasEscort(has_escort, requirements)`; wir setzen
+//     das Feld hier zusätzlich explizit, damit die Konsistenz auch auf
+//     FormData-Ebene garantiert ist (AC #135).
+//
+// Zusätzlich wird der daraus abgeleitete Fahrzeugtyp (`requirementsToVehicleType`,
+// #126) rein informativ angezeigt — es findet KEIN Fahrer-/Fahrzeug-Assignment
+// statt (out of scope M13).
+//
+// TODO (#135, optional): Vorbelegung als entfernbarer Vorschlag aus
+// `patient_impairments` des gewählten Patienten. Das ist mit dem aktuellen
+// Props-Contract NICHT möglich — `RequirementChips` erhält weder den Patienten
+// noch dessen Impairments. Dafür müsste der Kern (`ride-capture-form.tsx`) die
+// Impairments des gewählten Patienten laden/durchreichen (baut auf #126 auf).
 
-import { Tag } from "lucide-react"
-import type { RideRequirement } from "@/lib/rides/requirements"
+import { Car, Check } from "lucide-react"
+import { cn } from "@/lib/utils"
+import {
+  RIDE_REQUIREMENTS,
+  requirementsToVehicleType,
+  type RideRequirement,
+} from "@/lib/rides/requirements"
+import { RIDE_REQUIREMENT_LABELS, VEHICLE_TYPE_LABELS } from "@/lib/rides/constants"
 
 export interface RequirementChipsProps {
   /** Currently selected requirements. */
@@ -16,18 +38,72 @@ export interface RequirementChipsProps {
   onChange: (value: RideRequirement[]) => void
 }
 
-export function RequirementChips({ value }: RequirementChipsProps) {
+export function RequirementChips({ value, onChange }: RequirementChipsProps) {
+  const toggle = (req: RideRequirement): void => {
+    onChange(
+      value.includes(req)
+        ? value.filter((r) => r !== req)
+        : [...value, req]
+    )
+  }
+
+  const vehicleType = requirementsToVehicleType(value)
+  const hasCompanion = value.includes("companion")
+
   return (
-    <div className="space-y-1.5">
+    <div className="space-y-2.5">
       {/* Hidden inputs so the current selection is submitted with the form.
           `requirements` is a multi-value field parsed via formData.getAll(). */}
       {value.map((req) => (
         <input key={req} type="hidden" name="requirements" value={req} />
       ))}
-      <div className="flex items-center gap-2 rounded-lg border border-dashed bg-muted/30 px-3 py-2.5 text-xs text-muted-foreground">
-        <Tag className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-        <span>Bedarfs-Chips folgen (#135)</span>
+      {/* Keep `has_escort` consistent with the "Begleitung" chip (tariff-relevant,
+          AC #135). The server additionally derives this from `requirements`. */}
+      {hasCompanion && <input type="hidden" name="has_escort" value="true" />}
+
+      <div
+        className="flex flex-wrap gap-2"
+        role="group"
+        aria-label="Bedarf für die Fahrt"
+      >
+        {RIDE_REQUIREMENTS.map((req) => {
+          const selected = value.includes(req)
+          return (
+            <button
+              key={req}
+              type="button"
+              onClick={() => toggle(req)}
+              aria-pressed={selected}
+              className={cn(
+                // Large tap target for touch / 60+ usability.
+                "inline-flex min-h-[2.5rem] items-center gap-1.5 rounded-full border px-3.5 py-2 text-sm font-medium transition-colors",
+                "focus:outline-none focus:ring-2 focus:ring-ring/40 focus:ring-offset-1",
+                selected
+                  ? "border-primary bg-primary/10 text-primary"
+                  : "border-input bg-white text-muted-foreground hover:bg-muted/50"
+              )}
+            >
+              <Check
+                className={cn(
+                  "h-3.5 w-3.5 shrink-0 transition-opacity",
+                  selected ? "opacity-100" : "opacity-0"
+                )}
+                aria-hidden="true"
+              />
+              {RIDE_REQUIREMENT_LABELS[req]}
+            </button>
+          )
+        })}
       </div>
+
+      {/* Derived vehicle type — informative only (#126). No assignment happens. */}
+      <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Car className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        Benötigtes Fahrzeug:{" "}
+        <span className="font-medium text-foreground">
+          {VEHICLE_TYPE_LABELS[vehicleType]}
+        </span>
+      </p>
     </div>
   )
 }

--- a/src/components/rides/capture/requirement-chips.tsx
+++ b/src/components/rides/capture/requirement-chips.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+// SLOT (#135): Bedarfs-Chips (Rollstuhl, Rollator, Begleitung, Sauerstoff, …).
+// Functional stub: renders a labeled placeholder and mirrors the current value
+// into hidden `requirements` inputs so form submission already carries them.
+// Issue #135 builds the toggleable chip UI (multi-select) on top of the same
+// props contract — the core owns the `value`/`onChange` state.
+
+import { Tag } from "lucide-react"
+import type { RideRequirement } from "@/lib/rides/requirements"
+
+export interface RequirementChipsProps {
+  /** Currently selected requirements. */
+  value: RideRequirement[]
+  /** Toggle handler (replaces the whole set). */
+  onChange: (value: RideRequirement[]) => void
+}
+
+export function RequirementChips({ value }: RequirementChipsProps) {
+  return (
+    <div className="space-y-1.5">
+      {/* Hidden inputs so the current selection is submitted with the form.
+          `requirements` is a multi-value field parsed via formData.getAll(). */}
+      {value.map((req) => (
+        <input key={req} type="hidden" name="requirements" value={req} />
+      ))}
+      <div className="flex items-center gap-2 rounded-lg border border-dashed bg-muted/30 px-3 py-2.5 text-xs text-muted-foreground">
+        <Tag className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span>Bedarfs-Chips folgen (#135)</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/rides/capture/ride-map-panel.tsx
+++ b/src/components/rides/capture/ride-map-panel.tsx
@@ -1,13 +1,18 @@
 "use client"
 
 // SLOT (#132): Live-Karte im rechten Ergebnispanel.
-// Functional stub: renders a labeled placeholder and the raw route figures the
-// core already computed. Issue #132 replaces the placeholder body with the
-// interactive/static map (e.g. the existing <RouteMap>) using the `route`
-// coordinates + polyline. Keep this props contract stable.
+//
+// The core (ride-capture-form) already computes the route once via the
+// `calculateRouteForRide` server action and hands the result down as `route`.
+// This panel only *renders* that result -- it never issues a Maps web-service
+// call of its own (Marco's cost constraint). The map itself reuses the shared
+// <RouteMap>, which draws the static-map image client-side with the public,
+// referer-restricted key. On top of the map we surface distance + drive time
+// (AC #132) and a non-blocking hint when the route could not be resolved.
 
-import { MapPin } from "lucide-react"
+import { Clock, MapPin, Navigation } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { RouteMap } from "@/components/shared/route-map"
 import type { RouteInfo } from "./types"
 
 export interface RideMapPanelProps {
@@ -32,31 +37,71 @@ function formatDuration(seconds: number): string {
 }
 
 export function RideMapPanel({ route, isLoading, error }: RideMapPanelProps) {
+  // <RouteMap> only renders with a valid API key. Without it we still want the
+  // labelled card (and the metrics strip below) so the panel never disappears.
+  const hasApiKey = Boolean(process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY)
+
   return (
-    <Card>
-      <CardHeader className="pb-2">
-        <div className="flex items-center gap-2">
-          <MapPin className="h-4 w-4 text-muted-foreground" />
-          <CardTitle className="text-base">Route</CardTitle>
+    <div className="space-y-2">
+      {route !== null && hasApiKey ? (
+        <RouteMap
+          originLat={route.origin_lat}
+          originLng={route.origin_lng}
+          destLat={route.dest_lat}
+          destLng={route.dest_lng}
+          polyline={route.polyline}
+        />
+      ) : (
+        <Card>
+          <CardHeader className="pb-2">
+            <div className="flex items-center gap-2">
+              <MapPin className="h-4 w-4 text-muted-foreground" />
+              <CardTitle className="text-base">Route</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div
+              className="flex h-32 items-center justify-center rounded-lg border border-dashed bg-muted/30 px-3 text-center text-xs text-muted-foreground"
+              aria-live="polite"
+            >
+              {isLoading
+                ? "Route wird berechnet…"
+                : route !== null
+                  ? "Kartenvorschau nicht verfügbar (kein Karten-Schlüssel) — Distanz und Fahrzeit siehe unten."
+                  : "Karte erscheint, sobald Patient und Ziel gewählt sind."}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {route !== null && (
+        <div className="flex items-center justify-between gap-3 rounded-lg border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+          <span className="flex items-center gap-1.5">
+            <Navigation className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            <span>
+              Distanz:{" "}
+              <span className="font-medium text-foreground">
+                {formatDistance(route.distance_meters)}
+              </span>
+            </span>
+          </span>
+          <span className="flex items-center gap-1.5">
+            <Clock className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            <span>
+              Fahrzeit:{" "}
+              <span className="font-medium text-foreground">
+                {formatDuration(route.duration_seconds)}
+              </span>
+            </span>
+          </span>
         </div>
-      </CardHeader>
-      <CardContent className="space-y-2">
-        <div
-          className="flex h-32 items-center justify-center rounded-lg border border-dashed bg-muted/30 text-center text-xs text-muted-foreground"
-          aria-live="polite"
-        >
-          {isLoading
-            ? "Route wird berechnet…"
-            : route
-              ? `Kartenvorschau folgt (#132) · ${formatDistance(route.distance_meters)} · ${formatDuration(route.duration_seconds)} Fahrzeit`
-              : "Karte erscheint, sobald Patient und Ziel gewählt sind"}
-        </div>
-        {error && (
-          <p className="text-xs text-amber-700" role="alert">
-            Route nicht verfügbar — die Fahrt kann trotzdem gespeichert werden.
-          </p>
-        )}
-      </CardContent>
-    </Card>
+      )}
+
+      {error !== null && (
+        <p className="text-xs text-amber-700" role="alert">
+          Route nicht verfügbar — die Fahrt kann trotzdem gespeichert werden.
+        </p>
+      )}
+    </div>
   )
 }

--- a/src/components/rides/capture/ride-map-panel.tsx
+++ b/src/components/rides/capture/ride-map-panel.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+// SLOT (#132): Live-Karte im rechten Ergebnispanel.
+// Functional stub: renders a labeled placeholder and the raw route figures the
+// core already computed. Issue #132 replaces the placeholder body with the
+// interactive/static map (e.g. the existing <RouteMap>) using the `route`
+// coordinates + polyline. Keep this props contract stable.
+
+import { MapPin } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type { RouteInfo } from "./types"
+
+export interface RideMapPanelProps {
+  /** Calculated route (coords + polyline + distance/duration), or null. */
+  route: RouteInfo | null
+  /** True while the route request is in flight. */
+  isLoading: boolean
+  /** Route calculation error (non-blocking), or null. */
+  error: string | null
+}
+
+function formatDistance(meters: number): string {
+  return (meters / 1000).toFixed(1) + " km"
+}
+
+function formatDuration(seconds: number): string {
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `${minutes} Min.`
+  const hours = Math.floor(minutes / 60)
+  const rest = minutes % 60
+  return rest > 0 ? `${hours} Std. ${rest} Min.` : `${hours} Std.`
+}
+
+export function RideMapPanel({ route, isLoading, error }: RideMapPanelProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center gap-2">
+          <MapPin className="h-4 w-4 text-muted-foreground" />
+          <CardTitle className="text-base">Route</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div
+          className="flex h-32 items-center justify-center rounded-lg border border-dashed bg-muted/30 text-center text-xs text-muted-foreground"
+          aria-live="polite"
+        >
+          {isLoading
+            ? "Route wird berechnet…"
+            : route
+              ? `Kartenvorschau folgt (#132) · ${formatDistance(route.distance_meters)} · ${formatDuration(route.duration_seconds)} Fahrzeit`
+              : "Karte erscheint, sobald Patient und Ziel gewählt sind"}
+        </div>
+        {error && (
+          <p className="text-xs text-amber-700" role="alert">
+            Route nicht verfügbar — die Fahrt kann trotzdem gespeichert werden.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/rides/capture/ride-price-panel.tsx
+++ b/src/components/rides/capture/ride-price-panel.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+// SLOT (#133): Live-Preis/Tarif im rechten Ergebnispanel.
+// Functional stub: renders a labeled placeholder. Issue #133 computes and shows
+// the Dübendorf tariff breakdown from these inputs (zone from destination PLZ,
+// distance from `route`, `durationCategory`, escort/requirements, `rideType`
+// for round-trip pricing). The server action stays authoritative on save.
+
+import { CreditCard } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type { RideRequirement } from "@/lib/rides/requirements"
+import type {
+  CaptureDestination,
+  DurationCategory,
+  RideType,
+  RouteInfo,
+} from "./types"
+
+export interface RidePricePanelProps {
+  /** Selected destination (its PLZ drives the tariff zone), or null. */
+  destination: CaptureDestination | null
+  /** Calculated route (its distance drives ausserkantonal per-km fares), or null. */
+  route: RouteInfo | null
+  /** Stay-duration bucket derived from the appointment duration. */
+  durationCategory: DurationCategory
+  /** Ride requirements (e.g. `companion` implies an escort surcharge). */
+  requirements: RideRequirement[]
+  /** Round-trip vs. one-way — affects the tariff. */
+  rideType: RideType
+}
+
+export function RidePricePanel(_props: RidePricePanelProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center gap-2">
+          <CreditCard className="h-4 w-4 text-muted-foreground" />
+          <CardTitle className="text-base">Preis</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="flex h-16 items-center justify-center rounded-lg border border-dashed bg-muted/30 text-center text-xs text-muted-foreground">
+          Tarifberechnung folgt (#133)
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/rides/capture/ride-price-panel.tsx
+++ b/src/components/rides/capture/ride-price-panel.tsx
@@ -1,14 +1,30 @@
 "use client"
 
 // SLOT (#133): Live-Preis/Tarif im rechten Ergebnispanel.
-// Functional stub: renders a labeled placeholder. Issue #133 computes and shows
-// the Dübendorf tariff breakdown from these inputs (zone from destination PLZ,
-// distance from `route`, `durationCategory`, escort/requirements, `rideType`
-// for round-trip pricing). The server action stays authoritative on save.
+//
+// Reuses the exact client-side tariff pipeline already wired into `ride-form`:
+//   destination PLZ  --determineTariffZone-->  zone
+//   zone + direction + duration + escort + km  --calculateDuebendorfTariff-->  price
+// The breakdown is rendered by the shared <TariffPriceDisplay>. This mirrors the
+// authoritative server calculation in `calculateRidePrice` (#130); the action
+// stays the source of truth on save. No DB call happens here -- the client zone
+// lookup passes `null` for the DB zone name (same as `ride-form`), so PLZ that
+// only resolve via the DB table fall through to `ausserkantonal`.
 
 import { CreditCard } from "lucide-react"
+import { useMemo } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  calculateDuebendorfTariff,
+  TARIFF_ZONE_LABELS,
+  type TariffResult,
+} from "@/lib/billing/duebendorf-tariff"
+import {
+  determineTariffZone,
+  isTagesheimImwil,
+} from "@/lib/billing/zone-determination"
 import type { RideRequirement } from "@/lib/rides/requirements"
+import { TariffPriceDisplay } from "../tariff-price-display"
 import type {
   CaptureDestination,
   DurationCategory,
@@ -29,7 +45,60 @@ export interface RidePricePanelProps {
   rideType: RideType
 }
 
-export function RidePricePanel(_props: RidePricePanelProps) {
+/**
+ * Discriminated result of the live tariff calculation: either a computed price
+ * or a specific reason why no price can be shown yet. Each reason maps to a
+ * friendly, non-blocking placeholder (AC #133) instead of an error.
+ */
+type PriceState =
+  | { status: "ok"; result: TariffResult }
+  | { status: "no-destination" }
+  | { status: "no-plz" }
+  | { status: "needs-route" }
+
+/** Map the capture ride type onto the tariff direction. */
+function toTariffDirection(rideType: RideType): "outbound" | "both" {
+  return rideType === "round_trip" ? "both" : "outbound"
+}
+
+export function RidePricePanel({
+  destination,
+  route,
+  durationCategory,
+  requirements,
+  rideType,
+}: RidePricePanelProps) {
+  const state = useMemo<PriceState>(() => {
+    if (!destination) {
+      return { status: "no-destination" }
+    }
+    if (!destination.postal_code) {
+      return { status: "no-plz" }
+    }
+
+    // Client-side zone resolution (no DB zone name available here, same as the
+    // ride-form). Unknown PLZ fall through to `ausserkantonal`.
+    const zone = determineTariffZone(destination.postal_code, null)
+
+    // Ausserkantonal is priced per kilometre, so it requires the route distance.
+    // Until the core has computed the route, show a friendly hint rather than a
+    // misleading CHF 0.00.
+    if (zone === "ausserkantonal" && !route) {
+      return { status: "needs-route" }
+    }
+
+    const result = calculateDuebendorfTariff({
+      zone,
+      direction: toTariffDirection(rideType),
+      durationCategory,
+      isTagesheimImwil: isTagesheimImwil(destination.display_name),
+      hasEscort: requirements.includes("companion"),
+      distanceKm: route ? route.distance_meters / 1000 : 0,
+    })
+
+    return { status: "ok", result }
+  }, [destination, route, durationCategory, requirements, rideType])
+
   return (
     <Card>
       <CardHeader className="pb-2">
@@ -39,9 +108,27 @@ export function RidePricePanel(_props: RidePricePanelProps) {
         </div>
       </CardHeader>
       <CardContent>
-        <div className="flex h-16 items-center justify-center rounded-lg border border-dashed bg-muted/30 text-center text-xs text-muted-foreground">
-          Tarifberechnung folgt (#133)
-        </div>
+        {state.status === "ok" ? (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-xs text-muted-foreground">
+                Zone: {TARIFF_ZONE_LABELS[state.result.zone]}
+              </span>
+              <span className="text-lg font-semibold tabular-nums">
+                CHF {state.result.price.toFixed(2)}
+              </span>
+            </div>
+            <TariffPriceDisplay result={state.result} />
+          </div>
+        ) : (
+          <div className="flex h-16 items-center justify-center rounded-lg border border-dashed bg-muted/30 px-3 text-center text-xs text-muted-foreground">
+            {state.status === "no-destination"
+              ? "Preis erscheint, sobald ein Ziel gewählt ist."
+              : state.status === "no-plz"
+                ? "Für dieses Ziel ist keine PLZ hinterlegt — kein automatischer Tarif."
+                : "Für ausserkantonale Ziele wird die Route benötigt — der Preis erscheint, sobald sie berechnet ist."}
+          </div>
+        )}
       </CardContent>
     </Card>
   )

--- a/src/components/rides/capture/save-result-panel.tsx
+++ b/src/components/rides/capture/save-result-panel.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+/**
+ * SaveResultPanel — the post-save "never block" UX for the ride capture page
+ * (Issue #139).
+ *
+ * Shown after `createRide` (#130) returns success WITHOUT redirecting, which
+ * happens in two cases:
+ *   1. non-blocking warnings were collected (missing geo/route/price/appointment)
+ *   2. the user saved via "+ Auftragsblatt" (save_intent=order_sheet)
+ *
+ * It confirms the ride was saved, lists any warnings in a calm, informative
+ * (not alarming) amber block making clear the ride is safe and fixable later,
+ * and offers the two follow-up actions: continue to the day view or open the
+ * M11 order sheet (/api/mail/preview) for the freshly created ride.
+ */
+
+import Link from "next/link"
+import {
+  CheckCircle2,
+  Info,
+  FileText,
+  ArrowRight,
+  Plus,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import type { ActionWarning } from "@/actions/shared"
+
+export interface SaveResultPanelProps {
+  /** Id of the freshly created (outbound / series-initial) ride. */
+  rideId: string
+  /** Ride date (YYYY-MM-DD) — target of the day-view continue link. */
+  date: string
+  /** Non-blocking warnings from #130; empty when the save was fully clean. */
+  warnings: ActionWarning[]
+}
+
+export function SaveResultPanel({
+  rideId,
+  date,
+  warnings,
+}: SaveResultPanelProps) {
+  const hasWarnings = warnings.length > 0
+
+  return (
+    <section
+      className="space-y-4 rounded-lg border border-emerald-200 bg-emerald-50/70 p-4"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="flex items-start gap-2.5">
+        <CheckCircle2
+          className="mt-0.5 h-5 w-5 shrink-0 text-emerald-600"
+          aria-hidden="true"
+        />
+        <div className="space-y-0.5">
+          <p className="font-semibold text-emerald-900">Fahrt gespeichert</p>
+          <p className="text-sm text-emerald-800">
+            {hasWarnings
+              ? "Die Fahrt wurde gespeichert und kann jederzeit vervollständigt werden."
+              : "Die Fahrt wurde erfolgreich erfasst."}
+          </p>
+        </div>
+      </div>
+
+      {hasWarnings && (
+        <div className="rounded-md border border-amber-200 bg-amber-50 p-3">
+          <div className="flex items-center gap-2 text-amber-800">
+            <Info className="h-4 w-4 shrink-0" aria-hidden="true" />
+            <p className="text-sm font-medium">
+              Noch offen – ohne Auswirkung auf die Speicherung, später
+              korrigierbar:
+            </p>
+          </div>
+          <ul className="mt-2 space-y-1.5 text-sm text-amber-800">
+            {warnings.map((warning) => (
+              <li key={warning.code} className="flex gap-2">
+                <span aria-hidden="true" className="select-none">
+                  •
+                </span>
+                <span>{warning.message}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <Button asChild>
+          <Link href={`/rides?date=${date}`}>
+            Weiter zur Übersicht
+            <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+          </Link>
+        </Button>
+        <Button variant="outline" asChild>
+          <a
+            href={`/api/mail/preview?ride_id=${rideId}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <FileText className="mr-2 h-4 w-4" aria-hidden="true" />
+            Auftragsblatt öffnen
+          </a>
+        </Button>
+        {/*
+          Full page navigation (not next/link) so the capture form remounts with
+          a clean state for the next ride instead of keeping the saved result.
+        */}
+        <Button variant="ghost" asChild>
+          <a href="/rides/erfassen">
+            <Plus className="mr-2 h-4 w-4" aria-hidden="true" />
+            Weitere Fahrt erfassen
+          </a>
+        </Button>
+      </div>
+    </section>
+  )
+}

--- a/src/components/rides/capture/series-toggle.tsx
+++ b/src/components/rides/capture/series-toggle.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+// SLOT (#136): Wiederhol-/Serien-Toggle.
+// Functional stub: renders a labeled placeholder and the hidden `enable_series`
+// input the server action reads to branch into series creation. Issue #136 adds
+// the full recurrence UI (type, weekdays, end date, preview) on top of the same
+// props contract — the core owns all series state and passes setters down.
+
+import { Repeat } from "lucide-react"
+
+export interface SeriesToggleProps {
+  /** Whether the ride should be created as a recurring series. */
+  enabled: boolean
+  onEnabledChange: (enabled: boolean) => void
+  /** Recurrence type: daily | weekly | biweekly | monthly. */
+  recurrenceType: string
+  onRecurrenceTypeChange: (value: string) => void
+  /** Selected weekdays (for weekly/biweekly). */
+  daysOfWeek: string[]
+  onDaysOfWeekChange: (days: string[]) => void
+  /** Optional ISO end date for the series. */
+  endDate: string
+  onEndDateChange: (value: string) => void
+  /** Current ride direction (drives the generated-count preview in #136). */
+  direction: string
+}
+
+export function SeriesToggle({ enabled }: SeriesToggleProps) {
+  return (
+    <div className="space-y-2">
+      {/* Hidden field consumed by createRide to branch into series creation. */}
+      <input type="hidden" name="enable_series" value={enabled ? "true" : ""} />
+      <div className="flex items-center gap-2 rounded-lg border border-dashed bg-muted/30 px-3 py-2.5 text-xs text-muted-foreground">
+        <Repeat className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span>Serien-/Wiederhol-Optionen folgen (#136)</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/rides/capture/series-toggle.tsx
+++ b/src/components/rides/capture/series-toggle.tsx
@@ -1,12 +1,26 @@
 "use client"
 
-// SLOT (#136): Wiederhol-/Serien-Toggle.
-// Functional stub: renders a labeled placeholder and the hidden `enable_series`
-// input the server action reads to branch into series creation. Issue #136 adds
-// the full recurrence UI (type, weekdays, end date, preview) on top of the same
-// props contract — the core owns all series state and passes setters down.
+// SLOT (#136): Wiederhol-/Serien-Toggle für die Fahrt-Erfassung.
+//
+// Blendet bei aktivem "Wiederholen"-Schalter die Serienfelder ein
+// (Wiederholungs-Typ, Wochentage, Enddatum) und zeigt eine Vorschau der Anzahl
+// generierter Fahrten. Nutzt das bestehende Fahrtserien-Modell/-Muster aus
+// `ride-form.tsx`:
+//   - `enable_series` = "true" → `createRide` delegiert an `createRideWithSeries`.
+//   - `recurrence_type`, `days_of_week` (multi), `series_end_date` sind die vom
+//     Server erwarteten FormData-Feldnamen (siehe `seriesFieldsSchema`).
+//
+// Der Kern (`ride-capture-form.tsx`) besitzt den State; dieser Slot rendert nur
+// die UI und die versteckten Formularfelder. Für Touch-/60+-Bedienung werden
+// große Toggle-Buttons statt Dropdown/Mini-Checkboxen verwendet; die Auswahl
+// wird über versteckte Inputs an das Formular übergeben.
 
-import { Repeat } from "lucide-react"
+import { useMemo } from "react"
+import { CalendarRange, Check, Repeat } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { generateDatesForSeries } from "@/lib/ride-series/generate"
 
 export interface SeriesToggleProps {
   /** Whether the ride should be created as a recurring series. */
@@ -21,19 +35,244 @@ export interface SeriesToggleProps {
   /** Optional ISO end date for the series. */
   endDate: string
   onEndDateChange: (value: string) => void
-  /** Current ride direction (drives the generated-count preview in #136). */
+  /** Current ride direction (drives the generated-count preview). */
   direction: string
 }
 
-export function SeriesToggle({ enabled }: SeriesToggleProps) {
+type RecurrenceType = "daily" | "weekly" | "biweekly" | "monthly"
+type DayValue =
+  | "monday"
+  | "tuesday"
+  | "wednesday"
+  | "thursday"
+  | "friday"
+  | "saturday"
+  | "sunday"
+
+const RECURRENCE_OPTIONS: ReadonlyArray<{ value: RecurrenceType; label: string }> = [
+  { value: "daily", label: "Täglich" },
+  { value: "weekly", label: "Wöchentlich" },
+  { value: "biweekly", label: "Alle 2 Wochen" },
+  { value: "monthly", label: "Monatlich" },
+]
+
+const WEEKDAYS: ReadonlyArray<{ value: DayValue; label: string }> = [
+  { value: "monday", label: "Mo" },
+  { value: "tuesday", label: "Di" },
+  { value: "wednesday", label: "Mi" },
+  { value: "thursday", label: "Do" },
+  { value: "friday", label: "Fr" },
+  { value: "saturday", label: "Sa" },
+  { value: "sunday", label: "So" },
+]
+
+/** Default preview window (days) when no explicit end date is set. */
+const PREVIEW_WINDOW_DAYS = 30
+
+export function SeriesToggle({
+  enabled,
+  onEnabledChange,
+  recurrenceType,
+  onRecurrenceTypeChange,
+  daysOfWeek,
+  onDaysOfWeekChange,
+  endDate,
+  onEndDateChange,
+  direction,
+}: SeriesToggleProps) {
+  const showWeekdays =
+    recurrenceType === "weekly" || recurrenceType === "biweekly"
+
+  const toggleDay = (day: DayValue): void => {
+    onDaysOfWeekChange(
+      daysOfWeek.includes(day)
+        ? daysOfWeek.filter((d) => d !== day)
+        : [...daysOfWeek, day]
+    )
+  }
+
+  // --- Preview: how many rides the series would generate (informative). ---
+  const previewCount = useMemo<number | null>(() => {
+    if (!enabled || !recurrenceType) return null
+    const today = new Date().toISOString().split("T")[0]!
+    const windowEnd = new Date(
+      Date.now() + PREVIEW_WINDOW_DAYS * 24 * 60 * 60 * 1000
+    )
+      .toISOString()
+      .split("T")[0]!
+    try {
+      const dates = generateDatesForSeries(
+        {
+          recurrence_type: recurrenceType as RecurrenceType,
+          days_of_week:
+            daysOfWeek.length > 0 ? (daysOfWeek as DayValue[]) : null,
+          start_date: today,
+          end_date: endDate || null,
+        },
+        today,
+        endDate || windowEnd
+      )
+      // A round trip ("both") produces an outbound + return per date.
+      return direction === "both" ? dates.length * 2 : dates.length
+    } catch {
+      return null
+    }
+  }, [enabled, recurrenceType, daysOfWeek, endDate, direction])
+
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       {/* Hidden field consumed by createRide to branch into series creation. */}
       <input type="hidden" name="enable_series" value={enabled ? "true" : ""} />
-      <div className="flex items-center gap-2 rounded-lg border border-dashed bg-muted/30 px-3 py-2.5 text-xs text-muted-foreground">
-        <Repeat className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-        <span>Serien-/Wiederhol-Optionen folgen (#136)</span>
-      </div>
+
+      {/* --- Master toggle (large, touch-/60+-friendly) --- */}
+      <button
+        type="button"
+        onClick={() => onEnabledChange(!enabled)}
+        aria-pressed={enabled}
+        className={cn(
+          "flex w-full items-center gap-3 rounded-lg border px-3.5 py-3 text-left transition-colors",
+          "focus:outline-none focus:ring-2 focus:ring-ring/40 focus:ring-offset-1",
+          enabled
+            ? "border-primary bg-primary/5"
+            : "border-input bg-white hover:bg-muted/50"
+        )}
+      >
+        <span
+          className={cn(
+            "flex h-9 w-9 shrink-0 items-center justify-center rounded-md",
+            enabled ? "bg-primary/10 text-primary" : "bg-muted text-muted-foreground"
+          )}
+          aria-hidden="true"
+        >
+          <Repeat className="h-4 w-4" />
+        </span>
+        <span className="flex-1">
+          <span className="block text-sm font-medium text-foreground">
+            Fahrt wiederholen
+          </span>
+          <span className="block text-xs text-muted-foreground">
+            Als regelmäßige Fahrtserie anlegen
+          </span>
+        </span>
+        {/* Switch-like visual indicator. */}
+        <span
+          className={cn(
+            "relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors",
+            enabled ? "bg-primary" : "bg-input"
+          )}
+          aria-hidden="true"
+        >
+          <span
+            className={cn(
+              "inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform",
+              enabled ? "translate-x-5" : "translate-x-0.5"
+            )}
+          />
+        </span>
+      </button>
+
+      {enabled && (
+        <div className="space-y-4 rounded-lg border bg-muted/30 p-4">
+          {/* Recurrence type */}
+          <div className="space-y-2">
+            <Label>Wiederholung</Label>
+            {/* Hidden field carrying the selected recurrence for the server. */}
+            <input type="hidden" name="recurrence_type" value={recurrenceType} />
+            <div className="grid grid-cols-2 gap-1.5 sm:grid-cols-4">
+              {RECURRENCE_OPTIONS.map((option) => {
+                const active = recurrenceType === option.value
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => onRecurrenceTypeChange(option.value)}
+                    aria-pressed={active}
+                    className={cn(
+                      "min-h-[2.5rem] rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors",
+                      "focus:outline-none focus:ring-2 focus:ring-ring/40 focus:ring-offset-1",
+                      active
+                        ? "border-primary bg-primary/10 text-primary"
+                        : "border-input bg-white text-muted-foreground hover:bg-muted/50"
+                    )}
+                  >
+                    {option.label}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+
+          {/* Weekdays (weekly / biweekly only) */}
+          {showWeekdays && (
+            <div className="space-y-2">
+              <Label>Wochentage</Label>
+              {/* Hidden multi-value field consumed via formData.getAll. */}
+              {daysOfWeek.map((day) => (
+                <input
+                  key={day}
+                  type="hidden"
+                  name="days_of_week"
+                  value={day}
+                />
+              ))}
+              <div
+                className="flex flex-wrap gap-1.5"
+                role="group"
+                aria-label="Wochentage der Serie"
+              >
+                {WEEKDAYS.map((day) => {
+                  const active = daysOfWeek.includes(day.value)
+                  return (
+                    <button
+                      key={day.value}
+                      type="button"
+                      onClick={() => toggleDay(day.value)}
+                      aria-pressed={active}
+                      className={cn(
+                        "inline-flex min-h-[2.5rem] min-w-[2.75rem] items-center justify-center gap-1 rounded-lg border px-2.5 py-2 text-sm font-medium transition-colors",
+                        "focus:outline-none focus:ring-2 focus:ring-ring/40 focus:ring-offset-1",
+                        active
+                          ? "border-primary bg-primary/10 text-primary"
+                          : "border-input bg-white text-muted-foreground hover:bg-muted/50"
+                      )}
+                    >
+                      {active && (
+                        <Check className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                      )}
+                      {day.label}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* End date */}
+          <div className="space-y-2">
+            <Label htmlFor="series_end_date">Enddatum (optional)</Label>
+            <Input
+              id="series_end_date"
+              name="series_end_date"
+              type="date"
+              value={endDate}
+              onChange={(e) => onEndDateChange(e.target.value)}
+            />
+          </div>
+
+          {/* Preview */}
+          {previewCount !== null && (
+            <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <CalendarRange className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              Generiert ca.{" "}
+              <span className="font-medium text-foreground">
+                {previewCount}
+              </span>{" "}
+              {previewCount === 1 ? "Fahrt" : "Fahrten"}
+              {!endDate ? " (nächste 30 Tage)" : ""}
+            </p>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/rides/capture/types.ts
+++ b/src/components/rides/capture/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared types for the "Fahrt erfassen" two-column capture page (Issue #131).
+ *
+ * These are the contract between the core {@link RideCaptureForm} and its slot
+ * components (#132–#137). The core owns all state; slots receive the relevant
+ * slice plus setters via their own `*Props` interfaces (co-located in each slot
+ * file). Keeping the shared shapes here avoids a circular import between the
+ * core and the slots.
+ */
+
+import type { Enums } from "@/lib/types/database"
+import type { DurationCategory } from "@/lib/billing/duebendorf-tariff"
+
+/**
+ * Result of a route calculation (mirrors the payload of
+ * `calculateRouteForRide` in `@/actions/rides`). The core fetches it once and
+ * hands it down to the map (#132) and price (#133) panels, and uses
+ * `duration_seconds` to seed the live pickup-time suggestion.
+ */
+export interface RouteInfo {
+  distance_meters: number
+  duration_seconds: number
+  origin_lat: number
+  origin_lng: number
+  dest_lat: number
+  dest_lng: number
+  polyline: string
+}
+
+/** Minimal patient shape needed by the capture page (list + cost bearer). */
+export interface CapturePatient {
+  id: string
+  first_name: string
+  last_name: string
+  cost_bearer: Enums<"cost_bearer_type"> | null
+}
+
+/** Minimal destination shape needed by the capture page. */
+export interface CaptureDestination {
+  id: string
+  display_name: string
+  postal_code: string | null
+}
+
+/**
+ * The trip type toggle. `round_trip` (Hin + Rück) is the default and creates a
+ * linked return ride from the appointment duration (Design #2/#5); `one_way`
+ * (Einzelfahrt) captures only the outbound leg.
+ */
+export type RideType = "round_trip" | "one_way"
+
+/** Re-exported for slot components: tariff stay-duration bucket. */
+export type { DurationCategory }

--- a/src/components/rides/ride-capture-form.tsx
+++ b/src/components/rides/ride-capture-form.tsx
@@ -14,9 +14,14 @@
  * appointment duration, the trip-type toggle (Hin / Hin+Rück) and the
  * overridable pickup time(s) with a live suggestion via `calculateRideTimes`.
  *
- * Persistence goes through the existing `createRide` server action (#130): on
- * the clean path it redirects to /rides; when non-blocking warnings are present
- * it returns them and we surface a basic banner here (full warning UX is #139).
+ * Persistence goes through the existing `createRide` server action (#130):
+ *   - "Speichern & zur Übersicht" (save_intent=list) redirects to the day view
+ *     on the clean path; if warnings exist it returns them and we show the
+ *     post-save panel instead of navigating away.
+ *   - "+ Auftragsblatt" (save_intent=order_sheet) always skips the redirect so
+ *     we can hand the new ride id to the M11 order sheet (/api/mail/preview).
+ * The full "never block" warning UX (informative, non-alarming, save always
+ * possible) and the order-sheet hand-off are Issue #139.
  */
 
 import {
@@ -28,14 +33,12 @@ import {
   type FormEvent,
 } from "react"
 import { useFormState } from "react-dom"
-import Link from "next/link"
 import { cn } from "@/lib/utils"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Button } from "@/components/ui/button"
-import { SubmitButton } from "@/components/shared/submit-button"
 import { createRide, calculateRouteForRide } from "@/actions/rides"
 import { calculateRideTimes } from "@/lib/rides/time-calc"
 import { addMinutesToTime } from "@/lib/validations/rides"
@@ -51,6 +54,8 @@ import { RequirementChips } from "./capture/requirement-chips"
 import { SeriesToggle } from "./capture/series-toggle"
 import { RideMapPanel } from "./capture/ride-map-panel"
 import { RidePricePanel } from "./capture/ride-price-panel"
+import { CaptureSaveActions } from "./capture/capture-save-actions"
+import { SaveResultPanel } from "./capture/save-result-panel"
 import type {
   CapturePatient,
   CaptureDestination,
@@ -102,6 +107,13 @@ export function RideCaptureForm({
     FormData
   >(createRide, null)
   const fieldErrors = state && !state.success ? state.fieldErrors : undefined
+
+  // Post-save state (#139): createRide returned success without redirecting
+  // (warnings present or "+ Auftragsblatt"). We then show the SaveResultPanel
+  // and hide the save actions so the ride cannot be submitted twice.
+  const saved = state?.success === true
+  const savedRide = state?.success ? state.data : null
+  const saveWarnings = state?.success ? (state.warnings ?? []) : []
 
   // --- Lists (stateful so #134 can append inline-created entities) ---
   const [patientList, setPatientList] = useState(patients)
@@ -504,25 +516,14 @@ export function RideCaptureForm({
 
       {/* ================= RIGHT: live result ================= */}
       <aside className="space-y-4 lg:sticky lg:top-6">
-        {/* Non-blocking save warnings (#130). Full warning UX is #139. */}
-        {state?.success && state.warnings && state.warnings.length > 0 && (
-          <div
-            className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800"
-            role="status"
-          >
-            <p className="font-medium">Fahrt gespeichert — mit Hinweisen:</p>
-            <ul className="mt-1 list-disc space-y-0.5 pl-5">
-              {state.warnings.map((w) => (
-                <li key={w.code}>{w.message}</li>
-              ))}
-            </ul>
-            <Link
-              href={`/rides?date=${state.data.date}`}
-              className="mt-2 inline-block font-medium underline"
-            >
-              Weiter zu den Fahrten
-            </Link>
-          </div>
+        {/* Post-save panel (#139): confirmation + non-blocking warnings + the
+            "Weiter zur Übersicht" / "Auftragsblatt öffnen" follow-up actions. */}
+        {saved && savedRide && (
+          <SaveResultPanel
+            rideId={savedRide.id}
+            date={savedRide.date}
+            warnings={saveWarnings}
+          />
         )}
 
         <RideMapPanel
@@ -635,12 +636,9 @@ export function RideCaptureForm({
           rideType={rideType}
         />
 
-        <div className="flex gap-3">
-          <SubmitButton>Fahrt speichern</SubmitButton>
-          <Button variant="outline" asChild>
-            <Link href="/rides">Abbrechen</Link>
-          </Button>
-        </div>
+        {/* Save actions are hidden once saved so the ride is not submitted
+            twice; follow-up actions live in the SaveResultPanel above. */}
+        {!saved && <CaptureSaveActions />}
       </aside>
     </form>
   )

--- a/src/components/rides/ride-capture-form.tsx
+++ b/src/components/rides/ride-capture-form.tsx
@@ -104,8 +104,8 @@ export function RideCaptureForm({
   const fieldErrors = state && !state.success ? state.fieldErrors : undefined
 
   // --- Lists (stateful so #134 can append inline-created entities) ---
-  const [patientList] = useState(patients)
-  const [destinationList] = useState(destinations)
+  const [patientList, setPatientList] = useState(patients)
+  const [destinationList, setDestinationList] = useState(destinations)
 
   // --- WER ---
   const [selectedPatientId, setSelectedPatientId] = useState<string | null>(
@@ -149,6 +149,32 @@ export function RideCaptureForm({
   const selectedDestination = useMemo(
     () => destinationList.find((d) => d.id === selectedDestinationId) ?? null,
     [destinationList, selectedDestinationId]
+  )
+
+  // --- Inline-created entities (#134): append to the list + select immediately.
+  // Selecting triggers the route/price recalc via the effect below. ---
+  const handlePatientCreated = useCallback(
+    (patient: CapturePatient) => {
+      setPatientList((prev) =>
+        [...prev, patient].sort((a, b) =>
+          a.last_name.localeCompare(b.last_name)
+        )
+      )
+      setSelectedPatientId(patient.id)
+    },
+    []
+  )
+
+  const handleDestinationCreated = useCallback(
+    (destination: CaptureDestination) => {
+      setDestinationList((prev) =>
+        [...prev, destination].sort((a, b) =>
+          a.display_name.localeCompare(b.display_name)
+        )
+      )
+      setSelectedDestinationId(destination.id)
+    },
+    []
   )
 
   const durationMinutes = useMemo(() => {
@@ -278,6 +304,7 @@ export function RideCaptureForm({
                 patients={patientList}
                 value={selectedPatientId}
                 onChange={setSelectedPatientId}
+                onCreateNew={handlePatientCreated}
                 error={fieldErrors?.patient_id?.[0]}
                 autoFocus
               />
@@ -298,6 +325,7 @@ export function RideCaptureForm({
                 destinations={destinationList}
                 value={selectedDestinationId}
                 onChange={setSelectedDestinationId}
+                onCreateNew={handleDestinationCreated}
                 error={fieldErrors?.destination_id?.[0]}
               />
             </div>

--- a/src/components/rides/ride-capture-form.tsx
+++ b/src/components/rides/ride-capture-form.tsx
@@ -1,0 +1,619 @@
+"use client"
+
+/**
+ * RideCaptureForm — the core of the "Fahrt erfassen" one-page dispo (Issue #131).
+ *
+ * Mirrors the dispatch phone call as a two-column layout:
+ *   LEFT  = capture, in narrative order  WER → WOHIN & WANN → FAHRT
+ *   RIGHT = a permanently visible live result panel (map, pickup time(s), price,
+ *           warnings), sticky on desktop, stacked below on mobile.
+ *
+ * This component owns ALL state and composes slot components (#132–#137) that
+ * later agents fill in — it deliberately does NOT extend the edit-flow
+ * `ride-form.tsx`. The core fields built here are: appointment (date/time),
+ * appointment duration, the trip-type toggle (Hin / Hin+Rück) and the
+ * overridable pickup time(s) with a live suggestion via `calculateRideTimes`.
+ *
+ * Persistence goes through the existing `createRide` server action (#130): on
+ * the clean path it redirects to /rides; when non-blocking warnings are present
+ * it returns them and we surface a basic banner here (full warning UX is #139).
+ */
+
+import {
+  useState,
+  useMemo,
+  useEffect,
+  useCallback,
+  useTransition,
+  type FormEvent,
+} from "react"
+import { useFormState } from "react-dom"
+import Link from "next/link"
+import { cn } from "@/lib/utils"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/button"
+import { SubmitButton } from "@/components/shared/submit-button"
+import { createRide, calculateRouteForRide } from "@/actions/rides"
+import { calculateRideTimes } from "@/lib/rides/time-calc"
+import { addMinutesToTime } from "@/lib/validations/rides"
+import type { RideTimeBuffers } from "@/lib/rides/time-buffers"
+import type { RideRequirement } from "@/lib/rides/requirements"
+import type { ActionResult } from "@/actions/shared"
+import type { Tables } from "@/lib/types/database"
+
+import { CapturePatientField } from "./capture/capture-patient-field"
+import { CaptureDestinationField } from "./capture/capture-destination-field"
+import { CostBearerDisplay } from "./capture/cost-bearer-display"
+import { RequirementChips } from "./capture/requirement-chips"
+import { SeriesToggle } from "./capture/series-toggle"
+import { RideMapPanel } from "./capture/ride-map-panel"
+import { RidePricePanel } from "./capture/ride-price-panel"
+import type {
+  CapturePatient,
+  CaptureDestination,
+  RideType,
+  RouteInfo,
+  DurationCategory,
+} from "./capture/types"
+
+export interface RideCaptureFormProps {
+  patients: CapturePatient[]
+  destinations: CaptureDestination[]
+  /** Org-wide time buffers so the client preview matches the server suggestion. */
+  timeBuffers: RideTimeBuffers
+  defaultDate?: string
+  defaultPatientId?: string
+  defaultDestinationId?: string
+}
+
+/** Appointment-duration threshold (minutes) at which the tariff bucket flips. */
+const OVER_2H_THRESHOLD_MINUTES = 120
+
+/** Quick-pick presets for the appointment duration (minutes). */
+const DURATION_PRESETS = [30, 45, 60, 90, 120, 180] as const
+
+function SectionHeader({ step, title }: { step: number; title: string }) {
+  return (
+    <div className="flex items-center gap-2.5">
+      <span
+        className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary"
+        aria-hidden="true"
+      >
+        {step}
+      </span>
+      <CardTitle className="text-base">{title}</CardTitle>
+    </div>
+  )
+}
+
+export function RideCaptureForm({
+  patients,
+  destinations,
+  timeBuffers,
+  defaultDate,
+  defaultPatientId,
+  defaultDestinationId,
+}: RideCaptureFormProps) {
+  const [state, formAction] = useFormState<
+    ActionResult<Tables<"rides">> | null,
+    FormData
+  >(createRide, null)
+  const fieldErrors = state && !state.success ? state.fieldErrors : undefined
+
+  // --- Lists (stateful so #134 can append inline-created entities) ---
+  const [patientList] = useState(patients)
+  const [destinationList] = useState(destinations)
+
+  // --- WER ---
+  const [selectedPatientId, setSelectedPatientId] = useState<string | null>(
+    defaultPatientId ?? null
+  )
+
+  // --- WOHIN & WANN ---
+  const [selectedDestinationId, setSelectedDestinationId] = useState<
+    string | null
+  >(defaultDestinationId ?? null)
+  const [date, setDate] = useState<string>(defaultDate ?? "")
+  const [appointmentTime, setAppointmentTime] = useState<string>("")
+  const [appointmentDuration, setAppointmentDuration] = useState<string>("")
+  const [requirements, setRequirements] = useState<RideRequirement[]>([])
+
+  // --- FAHRT ---
+  const [rideType, setRideType] = useState<RideType>("round_trip")
+
+  // --- Overridable pickup times ---
+  const [pickupTime, setPickupTime] = useState<string>("")
+  const [pickupManual, setPickupManual] = useState(false)
+  const [returnPickupTime, setReturnPickupTime] = useState<string>("")
+  const [returnManual, setReturnManual] = useState(false)
+
+  // --- Route (live result) ---
+  const [routeInfo, setRouteInfo] = useState<RouteInfo | null>(null)
+  const [routeError, setRouteError] = useState<string | null>(null)
+  const [isCalculatingRoute, startRouteTransition] = useTransition()
+
+  // --- Series (owned here, rendered by the #136 slot) ---
+  const [enableSeries, setEnableSeries] = useState(false)
+  const [recurrenceType, setRecurrenceType] = useState<string>("weekly")
+  const [daysOfWeek, setDaysOfWeek] = useState<string[]>([])
+  const [seriesEndDate, setSeriesEndDate] = useState<string>("")
+
+  // --- Derived values ---
+  const selectedPatient = useMemo(
+    () => patientList.find((p) => p.id === selectedPatientId) ?? null,
+    [patientList, selectedPatientId]
+  )
+  const selectedDestination = useMemo(
+    () => destinationList.find((d) => d.id === selectedDestinationId) ?? null,
+    [destinationList, selectedDestinationId]
+  )
+
+  const durationMinutes = useMemo(() => {
+    const parsed = parseInt(appointmentDuration, 10)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+  }, [appointmentDuration])
+
+  const appointmentEndTime = useMemo(() => {
+    if (!appointmentTime || durationMinutes <= 0) return ""
+    return addMinutesToTime(appointmentTime, durationMinutes) ?? ""
+  }, [appointmentTime, durationMinutes])
+
+  const durationCategory: DurationCategory =
+    durationMinutes >= OVER_2H_THRESHOLD_MINUTES ? "over_2h" : "under_2h"
+
+  const isRoundTrip = rideType === "round_trip"
+
+  // --- Live pickup-time suggestion (client preview; server is authoritative) ---
+  const suggestedTimes = useMemo(
+    () =>
+      calculateRideTimes({
+        appointment_time: appointmentTime || null,
+        appointment_end_time: appointmentEndTime || null,
+        duration_seconds: routeInfo?.duration_seconds ?? null,
+        pickupBufferMinutes: timeBuffers.pickupBufferMinutes,
+        boardingMinutes: timeBuffers.boardingMinutes,
+        returnBufferMinutes: timeBuffers.returnBufferMinutes,
+      }),
+    [appointmentTime, appointmentEndTime, routeInfo, timeBuffers]
+  )
+
+  // --- Route calculation on patient/destination change ---
+  const calculateRoute = useCallback(
+    (patientId: string, destinationId: string) => {
+      startRouteTransition(async () => {
+        setRouteError(null)
+        const result = await calculateRouteForRide(patientId, destinationId)
+        if (result.success) {
+          setRouteInfo(result.data)
+        } else {
+          setRouteError(result.error ?? "Routenberechnung fehlgeschlagen")
+          setRouteInfo(null)
+        }
+      })
+    },
+    []
+  )
+
+  useEffect(() => {
+    if (selectedPatientId && selectedDestinationId) {
+      calculateRoute(selectedPatientId, selectedDestinationId)
+    } else {
+      setRouteInfo(null)
+      setRouteError(null)
+    }
+  }, [selectedPatientId, selectedDestinationId, calculateRoute])
+
+  // --- Keep the suggested pickup times in the fields until manually overridden ---
+  useEffect(() => {
+    if (!pickupManual && suggestedTimes.suggestedPickupTime) {
+      setPickupTime(suggestedTimes.suggestedPickupTime)
+    }
+  }, [suggestedTimes.suggestedPickupTime, pickupManual])
+
+  useEffect(() => {
+    if (!returnManual && isRoundTrip && suggestedTimes.suggestedReturnPickupTime) {
+      setReturnPickupTime(suggestedTimes.suggestedReturnPickupTime)
+    }
+  }, [suggestedTimes.suggestedReturnPickupTime, returnManual, isRoundTrip])
+
+  // Resetting to the suggestion after a manual edit
+  const resetPickupToSuggestion = useCallback(() => {
+    if (suggestedTimes.suggestedPickupTime) {
+      setPickupTime(suggestedTimes.suggestedPickupTime)
+      setPickupManual(false)
+    }
+  }, [suggestedTimes.suggestedPickupTime])
+
+  const resetReturnToSuggestion = useCallback(() => {
+    if (suggestedTimes.suggestedReturnPickupTime) {
+      setReturnPickupTime(suggestedTimes.suggestedReturnPickupTime)
+      setReturnManual(false)
+    }
+  }, [suggestedTimes.suggestedReturnPickupTime])
+
+  // Guard: round trip needs an appointment end time (server enforces this too).
+  const roundTripMissingEnd = isRoundTrip && appointmentTime !== "" && !appointmentEndTime
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>): void {
+    // The core does not add client-side blocking; the server action validates
+    // and never blocks on geo/price (#130). Nothing to intercept here yet.
+    void event
+  }
+
+  return (
+    <form
+      action={formAction}
+      onSubmit={handleSubmit}
+      className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_minmax(360px,440px)] lg:items-start"
+    >
+      {/* Derived / hidden fields consumed by createRide (#130). */}
+      <input type="hidden" name="direction" value="outbound" />
+      <input type="hidden" name="appointment_end_time" value={appointmentEndTime} />
+      <input type="hidden" name="duration_category" value={durationCategory} />
+      {isRoundTrip && <input type="hidden" name="create_return_ride" value="true" />}
+
+      {/* ================= LEFT: capture ================= */}
+      <div className="space-y-6">
+        {state && !state.success && state.error && (
+          <p
+            className="rounded-md border border-destructive/40 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+            role="alert"
+          >
+            {state.error}
+          </p>
+        )}
+
+        {/* --- WER --- */}
+        <Card>
+          <CardHeader>
+            <SectionHeader step={1} title="Wer" />
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="space-y-2">
+              <Label>Patient</Label>
+              <CapturePatientField
+                patients={patientList}
+                value={selectedPatientId}
+                onChange={setSelectedPatientId}
+                error={fieldErrors?.patient_id?.[0]}
+                autoFocus
+              />
+            </div>
+            <CostBearerDisplay patient={selectedPatient} />
+          </CardContent>
+        </Card>
+
+        {/* --- WOHIN & WANN --- */}
+        <Card>
+          <CardHeader>
+            <SectionHeader step={2} title="Wohin & wann" />
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label>Ziel</Label>
+              <CaptureDestinationField
+                destinations={destinationList}
+                value={selectedDestinationId}
+                onChange={setSelectedDestinationId}
+                error={fieldErrors?.destination_id?.[0]}
+              />
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="date">Datum</Label>
+                <Input
+                  id="date"
+                  name="date"
+                  type="date"
+                  required
+                  value={date}
+                  onChange={(e) => setDate(e.target.value)}
+                />
+                {fieldErrors?.date && (
+                  <p className="text-sm text-destructive">
+                    {fieldErrors.date[0]}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="appointment_time">Terminbeginn</Label>
+                <Input
+                  id="appointment_time"
+                  name="appointment_time"
+                  type="time"
+                  value={appointmentTime}
+                  onChange={(e) => setAppointmentTime(e.target.value)}
+                />
+                {fieldErrors?.appointment_time && (
+                  <p className="text-sm text-destructive">
+                    {fieldErrors.appointment_time[0]}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            {/* Termindauer → derives appointment_end_time + tariff bucket */}
+            <div className="space-y-2">
+              <Label htmlFor="appointment_duration">Termindauer</Label>
+              <div className="flex flex-wrap items-center gap-2">
+                <Input
+                  id="appointment_duration"
+                  type="number"
+                  inputMode="numeric"
+                  min={0}
+                  step={15}
+                  placeholder="Minuten"
+                  className="w-32"
+                  value={appointmentDuration}
+                  onChange={(e) => setAppointmentDuration(e.target.value)}
+                />
+                <span className="text-sm text-muted-foreground">Min.</span>
+                <div className="flex flex-wrap gap-1.5">
+                  {DURATION_PRESETS.map((preset) => (
+                    <button
+                      key={preset}
+                      type="button"
+                      onClick={() => setAppointmentDuration(String(preset))}
+                      className={cn(
+                        "rounded-md border px-2.5 py-1 text-xs font-medium transition-colors",
+                        "focus:outline-none focus:ring-2 focus:ring-ring/40",
+                        durationMinutes === preset
+                          ? "border-primary bg-primary/10 text-primary"
+                          : "border-input bg-white text-muted-foreground hover:bg-muted/50"
+                      )}
+                      aria-pressed={durationMinutes === preset}
+                    >
+                      {preset < 60
+                        ? `${preset} Min`
+                        : preset % 60 === 0
+                          ? `${preset / 60} Std`
+                          : `${Math.floor(preset / 60)}:${String(preset % 60).padStart(2, "0")} Std`}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              {appointmentEndTime ? (
+                <p className="text-xs text-muted-foreground">
+                  Terminende:{" "}
+                  <span className="font-medium text-foreground">
+                    {appointmentEndTime}
+                  </span>{" "}
+                  (Terminbeginn + Termindauer)
+                </p>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Aus Terminbeginn + Dauer wird das Terminende und die
+                  Rückfahrt-Abholzeit berechnet.
+                </p>
+              )}
+              {fieldErrors?.appointment_end_time && (
+                <p className="text-sm text-destructive">
+                  {fieldErrors.appointment_end_time[0]}
+                </p>
+              )}
+            </div>
+
+            {/* Requirements (chips filled by #135) */}
+            <div className="space-y-2">
+              <Label>Bedarf</Label>
+              <RequirementChips
+                value={requirements}
+                onChange={setRequirements}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* --- FAHRT --- */}
+        <Card>
+          <CardHeader>
+            <SectionHeader step={3} title="Fahrt" />
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label>Fahrt-Typ</Label>
+              <div className="grid grid-cols-2 gap-1.5">
+                {(
+                  [
+                    { value: "round_trip", label: "Hin + Rück" },
+                    { value: "one_way", label: "Einzelfahrt (nur Hin)" },
+                  ] as const
+                ).map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => setRideType(option.value)}
+                    className={cn(
+                      "rounded-lg border px-3 py-2.5 text-sm font-medium transition-colors",
+                      "focus:outline-none focus:ring-2 focus:ring-ring/40 focus:ring-offset-1",
+                      rideType === option.value
+                        ? "border-primary bg-primary/10 text-primary"
+                        : "border-input bg-white text-muted-foreground hover:bg-muted/50"
+                    )}
+                    aria-pressed={rideType === option.value}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+              {roundTripMissingEnd && (
+                <p className="text-xs text-amber-700">
+                  Für die Rückfahrt bitte eine Termindauer erfassen, damit das
+                  Terminende bekannt ist.
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="notes">Notizen</Label>
+              <Textarea id="notes" name="notes" rows={3} defaultValue="" />
+              {fieldErrors?.notes && (
+                <p className="text-sm text-destructive">
+                  {fieldErrors.notes[0]}
+                </p>
+              )}
+            </div>
+
+            <SeriesToggle
+              enabled={enableSeries}
+              onEnabledChange={setEnableSeries}
+              recurrenceType={recurrenceType}
+              onRecurrenceTypeChange={setRecurrenceType}
+              daysOfWeek={daysOfWeek}
+              onDaysOfWeekChange={setDaysOfWeek}
+              endDate={seriesEndDate}
+              onEndDateChange={setSeriesEndDate}
+              direction="outbound"
+            />
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* ================= RIGHT: live result ================= */}
+      <aside className="space-y-4 lg:sticky lg:top-6">
+        {/* Non-blocking save warnings (#130). Full warning UX is #139. */}
+        {state?.success && state.warnings && state.warnings.length > 0 && (
+          <div
+            className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+            role="status"
+          >
+            <p className="font-medium">Fahrt gespeichert — mit Hinweisen:</p>
+            <ul className="mt-1 list-disc space-y-0.5 pl-5">
+              {state.warnings.map((w) => (
+                <li key={w.code}>{w.message}</li>
+              ))}
+            </ul>
+            <Link
+              href={`/rides?date=${state.data.date}`}
+              className="mt-2 inline-block font-medium underline"
+            >
+              Weiter zu den Fahrten
+            </Link>
+          </div>
+        )}
+
+        <RideMapPanel
+          route={routeInfo}
+          isLoading={isCalculatingRoute}
+          error={routeError}
+        />
+
+        {/* Overridable pickup time(s) */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Abholzeiten</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="pickup_time">
+                Hin-Abholung <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                id="pickup_time"
+                name="pickup_time"
+                type="time"
+                required
+                value={pickupTime}
+                onChange={(e) => {
+                  setPickupTime(e.target.value)
+                  setPickupManual(true)
+                }}
+              />
+              {suggestedTimes.suggestedPickupTime && (
+                <p className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+                  Vorschlag:{" "}
+                  <span className="font-medium text-foreground">
+                    {suggestedTimes.suggestedPickupTime}
+                  </span>
+                  {pickupManual &&
+                    pickupTime !== suggestedTimes.suggestedPickupTime && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-6 px-2 text-xs"
+                        onClick={resetPickupToSuggestion}
+                      >
+                        Übernehmen
+                      </Button>
+                    )}
+                </p>
+              )}
+              {fieldErrors?.pickup_time && (
+                <p className="text-sm text-destructive">
+                  {fieldErrors.pickup_time[0]}
+                </p>
+              )}
+            </div>
+
+            {isRoundTrip && (
+              <div className="space-y-2">
+                <Label htmlFor="return_pickup_time">Rück-Abholung</Label>
+                <Input
+                  id="return_pickup_time"
+                  name="return_pickup_time"
+                  type="time"
+                  value={returnPickupTime}
+                  onChange={(e) => {
+                    setReturnPickupTime(e.target.value)
+                    setReturnManual(true)
+                  }}
+                />
+                {suggestedTimes.suggestedReturnPickupTime ? (
+                  <p className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+                    Vorschlag:{" "}
+                    <span className="font-medium text-foreground">
+                      {suggestedTimes.suggestedReturnPickupTime}
+                    </span>
+                    {returnManual &&
+                      returnPickupTime !==
+                        suggestedTimes.suggestedReturnPickupTime && (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="h-6 px-2 text-xs"
+                          onClick={resetReturnToSuggestion}
+                        >
+                          Übernehmen
+                        </Button>
+                      )}
+                  </p>
+                ) : (
+                  <p className="text-xs text-muted-foreground">
+                    Wird aus dem Terminende berechnet.
+                  </p>
+                )}
+                {fieldErrors?.return_pickup_time && (
+                  <p className="text-sm text-destructive">
+                    {fieldErrors.return_pickup_time[0]}
+                  </p>
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <RidePricePanel
+          destination={selectedDestination}
+          route={routeInfo}
+          durationCategory={durationCategory}
+          requirements={requirements}
+          rideType={rideType}
+        />
+
+        <div className="flex gap-3">
+          <SubmitButton>Fahrt speichern</SubmitButton>
+          <Button variant="outline" asChild>
+            <Link href="/rides">Abbrechen</Link>
+          </Button>
+        </div>
+      </aside>
+    </form>
+  )
+}

--- a/src/components/rides/ride-form.tsx
+++ b/src/components/rides/ride-form.tsx
@@ -541,6 +541,32 @@ export function RideForm({
                 <p className="text-sm text-destructive" role="alert">{state.error}</p>
               )}
 
+              {/* Non-blocking persistence warnings (Issue #130). The ride was
+                  saved; these are hints, not errors. Full UI follows in #139. */}
+              {state?.success &&
+                state.warnings &&
+                state.warnings.length > 0 && (
+                  <div
+                    className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+                    role="status"
+                  >
+                    <p className="font-medium">
+                      Fahrt gespeichert — mit Hinweisen:
+                    </p>
+                    <ul className="mt-1 list-disc space-y-0.5 pl-5">
+                      {state.warnings.map((w) => (
+                        <li key={w.code}>{w.message}</li>
+                      ))}
+                    </ul>
+                    <Link
+                      href={`/rides?date=${state.data.date}`}
+                      className="mt-2 inline-block font-medium underline"
+                    >
+                      Weiter zu den Fahrten
+                    </Link>
+                  </div>
+                )}
+
               {/* Warning banner for linked rides (edit mode) */}
               {isEdit && hasLinkedRides && (
                 <div className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800">

--- a/src/components/settings/organization-settings-form.tsx
+++ b/src/components/settings/organization-settings-form.tsx
@@ -36,6 +36,11 @@ export function OrganizationSettingsForm({ settings }: Props) {
   const [emailMsg, setEmailMsg] = useState<{ ok: boolean; text: string } | null>(null)
   const [isSendingEmail, startEmailSend] = useTransition()
 
+  const fieldErrors =
+    state && !state.success ? state.fieldErrors : undefined
+  const fieldError = (name: string): string | undefined =>
+    fieldErrors?.[name]?.[0]
+
   function handleLogoUpload(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
     if (!file) return
@@ -373,6 +378,90 @@ export function OrganizationSettingsForm({ settings }: Props) {
               {emailMsg && (
                 <p className={`text-xs ${emailMsg.ok ? "text-emerald-600" : "text-red-600"}`}>
                   {emailMsg.text}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* ============================================================= */}
+        {/* Zeit-Puffer (Issue #128) */}
+        {/* ============================================================= */}
+        <div className="rounded-xl border border-slate-200 bg-white">
+          <div className="border-b border-slate-200 px-6 py-4">
+            <h2 className="text-base font-semibold">Zeit-Puffer</h2>
+            <p className="text-xs text-slate-500">
+              Standardwerte für die vorgeschlagene Abholzeit. Pro Fahrt
+              überschreibbar.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 gap-4 p-6 sm:grid-cols-3">
+            <div>
+              <Label htmlFor="default_pickup_buffer_minutes">
+                Vorlauf-Puffer (Min.)
+              </Label>
+              <Input
+                id="default_pickup_buffer_minutes"
+                name="default_pickup_buffer_minutes"
+                type="number"
+                min={0}
+                max={120}
+                step={1}
+                inputMode="numeric"
+                defaultValue={settings?.default_pickup_buffer_minutes ?? 5}
+              />
+              <p className="mt-1 text-xs text-slate-500">
+                Vor der Fahrtdauer, damit der Fahrer rechtzeitig da ist.
+              </p>
+              {fieldError("default_pickup_buffer_minutes") && (
+                <p className="mt-1 text-xs text-red-600">
+                  {fieldError("default_pickup_buffer_minutes")}
+                </p>
+              )}
+            </div>
+            <div>
+              <Label htmlFor="default_boarding_minutes">
+                Ein-/Aussteige-Zeit (Min.)
+              </Label>
+              <Input
+                id="default_boarding_minutes"
+                name="default_boarding_minutes"
+                type="number"
+                min={0}
+                max={120}
+                step={1}
+                inputMode="numeric"
+                defaultValue={settings?.default_boarding_minutes ?? 0}
+              />
+              <p className="mt-1 text-xs text-slate-500">
+                Zeit für das Boarding beim Patienten.
+              </p>
+              {fieldError("default_boarding_minutes") && (
+                <p className="mt-1 text-xs text-red-600">
+                  {fieldError("default_boarding_minutes")}
+                </p>
+              )}
+            </div>
+            <div>
+              <Label htmlFor="default_return_buffer_minutes">
+                Rückfahr-Puffer (Min.)
+              </Label>
+              <Input
+                id="default_return_buffer_minutes"
+                name="default_return_buffer_minutes"
+                type="number"
+                min={0}
+                max={120}
+                step={1}
+                inputMode="numeric"
+                defaultValue={settings?.default_return_buffer_minutes ?? 15}
+              />
+              <p className="mt-1 text-xs text-slate-500">
+                Nach dem Termin bis zur Rückfahr-Abholung.
+              </p>
+              {fieldError("default_return_buffer_minutes") && (
+                <p className="mt-1 text-xs text-red-600">
+                  {fieldError("default_return_buffer_minutes")}
                 </p>
               )}
             </div>

--- a/src/lib/mail/load-order-sheet-data.ts
+++ b/src/lib/mail/load-order-sheet-data.ts
@@ -133,11 +133,16 @@ interface DriverRow {
  * Uses the admin client (service role) to bypass RLS, consistent with
  * other mail functions that run in background/cron contexts.
  *
- * @throws Error if ride or driver is not found
+ * `driverId` is nullable: rides captured via the one-page dispo (#139) are
+ * unplanned and have no driver yet, but an order sheet must still be
+ * printable/previewable. When null, the driver fields are left empty and the
+ * order sheet renders a "not yet assigned" placeholder in the driver block.
+ *
+ * @throws Error if the ride (or a non-null driver) is not found
  */
 export async function loadOrderSheetData(
   rideId: string,
-  driverId: string,
+  driverId: string | null,
   confirmUrl: string,
   rejectUrl: string
 ): Promise<OrderSheetData> {
@@ -171,24 +176,40 @@ export async function loadOrderSheetData(
     throw new Error(`Failed to load ride ${rideId}: ${rideError?.message ?? "not found"}`)
   }
 
-  // Load driver
-  const { data: driver, error: driverError } = await supabase
-    .from("drivers")
-    .select(`
-      first_name, last_name, street, house_number,
-      postal_code, city, phone, email, vehicle_type
-    `)
-    .eq("id", driverId)
-    .single()
+  // Load driver (optional). Unplanned rides captured via #139 have no driver
+  // yet; the order sheet still renders with a placeholder driver block.
+  let driverData: DriverRow = {
+    first_name: "",
+    last_name: "",
+    street: null,
+    house_number: null,
+    postal_code: null,
+    city: null,
+    phone: null,
+    email: null,
+    vehicle_type: "",
+  }
 
-  if (driverError || !driver) {
-    throw new Error(`Failed to load driver ${driverId}: ${driverError?.message ?? "not found"}`)
+  if (driverId) {
+    const { data: driver, error: driverError } = await supabase
+      .from("drivers")
+      .select(`
+        first_name, last_name, street, house_number,
+        postal_code, city, phone, email, vehicle_type
+      `)
+      .eq("id", driverId)
+      .single()
+
+    if (driverError || !driver) {
+      throw new Error(`Failed to load driver ${driverId}: ${driverError?.message ?? "not found"}`)
+    }
+
+    driverData = driver as DriverRow
   }
 
   // Cast join results to typed aliases
   const patient = (ride as unknown as RideWithJoins).patients
   const destination = (ride as unknown as RideWithJoins).destinations
-  const driverData = driver as DriverRow
 
   // Load organization name (singleton row, fallback to default)
   const { data: orgSettings } = await supabase

--- a/src/lib/mail/templates/sections/driver-block.ts
+++ b/src/lib/mail/templates/sections/driver-block.ts
@@ -21,7 +21,10 @@ function row(label: string, value: string | null | undefined): string {
  * Null fields are omitted.
  */
 export function renderDriverBlock(data: OrderSheetData): string {
-  const fullName = `${data.driverFirstName} ${data.driverLastName}`
+  // Unplanned rides (#139) have no driver yet — render a placeholder instead
+  // of an empty block so the printed order sheet reads clearly.
+  const hasDriver = Boolean(data.driverFirstName || data.driverLastName)
+  const fullName = `${data.driverFirstName} ${data.driverLastName}`.trim()
 
   // Address line
   const addressLine =
@@ -62,12 +65,16 @@ export function renderDriverBlock(data: OrderSheetData): string {
       </tr>
     </table>
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="padding:12px 0;">
-      ${row("Name", fullName)}
+      ${
+        hasDriver
+          ? `${row("Name", fullName)}
       ${row("Adresse", addressLine)}
       ${row("PLZ / Ort", plzOrt)}
       ${row("Telefon / Mobile", data.driverPhone)}
       ${row("E-Mail", data.driverEmail)}
-      ${row("Fahrzeugtyp", vehicleLabel)}
+      ${row("Fahrzeugtyp", vehicleLabel)}`
+          : `<tr><td colspan="2" style="color:#92400e;font-size:14px;font-style:italic;padding:4px 0;">Noch kein Fahrer zugewiesen &ndash; bitte in der Disposition zuweisen.</td></tr>`
+      }
     </table>
     ${notesSection}
   </td>

--- a/src/lib/patients/constants.ts
+++ b/src/lib/patients/constants.ts
@@ -1,0 +1,38 @@
+import type { Tables } from "@/lib/types/database"
+
+/**
+ * Cost bearer (Kostenträger) options for a patient — Issue #125.
+ *
+ * The generated DB types (`src/lib/types/database.ts`) do NOT yet include the
+ * `cost_bearer` column or the `cost_bearer_type` enum; they are regenerated
+ * centrally after the M13 merge. Until then, this module is the single source of
+ * truth for the enum values, their German labels and a locally-extended patient
+ * type, so app code can read/write the column with an explicit, documented cast
+ * instead of `any`. Once the types are regenerated, prefer `Enums<"cost_bearer_type">`.
+ */
+export const COST_BEARER_VALUES = [
+  "health_insurance",
+  "self_payer",
+  "municipality",
+  "other",
+] as const
+
+export type CostBearer = (typeof COST_BEARER_VALUES)[number]
+
+export const COST_BEARER_LABELS: Record<CostBearer, string> = {
+  health_insurance: "Krankenkasse",
+  self_payer: "Selbstzahler",
+  municipality: "Gemeinde",
+  other: "Sonstiges",
+}
+
+/** Sentinel <Select> value meaning "no cost bearer chosen" — maps to NULL. */
+export const COST_BEARER_NONE = "__none__"
+
+/**
+ * Patient row extended with the not-yet-generated `cost_bearer` column.
+ * Use for READS until the DB types are regenerated (#125).
+ */
+export type PatientWithCostBearer = Tables<"patients"> & {
+  cost_bearer: CostBearer | null
+}

--- a/src/lib/rides/__tests__/appointment-end-derivation.test.ts
+++ b/src/lib/rides/__tests__/appointment-end-derivation.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest"
+import { addMinutesToTime } from "@/lib/validations/rides"
+
+/**
+ * Appointment-end derivation contract (Issue #131/#133, M13).
+ *
+ * The capture form (`ride-capture-form.tsx`) derives the hidden
+ * `appointment_end_time` field purely from the appointment start plus the
+ * chosen "Termindauer":
+ *
+ *     appointment_end_time = addMinutesToTime(appointmentTime, durationMinutes)
+ *
+ * The ternary and the `DURATION_PRESETS` array live inline in the client
+ * component and are therefore not importable in isolation without modifying M13
+ * source. This file instead pins the *arithmetic contract* the component relies
+ * on — the exported, pure `addMinutesToTime` helper — for every preset the UI
+ * offers, so a regression in the helper (rollover, overflow, padding) is caught.
+ *
+ * NOTE (honest coverage): the `durationMinutes >= 120 -> "over_2h"` bucket
+ * threshold itself is an inline component ternary (`OVER_2H_THRESHOLD_MINUTES`)
+ * and is NOT exercised here. Its downstream consumer,
+ * `calculateDuebendorfTariff`, is covered in
+ * `src/lib/billing/__tests__/duebendorf-tariff.test.ts`; the threshold wiring is
+ * verified manually / via the tariff preview in the browser (see ADR-014).
+ */
+
+// Mirror of the UI presets (documented, not imported — see file header).
+const DURATION_PRESETS = [30, 45, 60, 90, 120, 180] as const
+
+describe("appointment_end_time derivation (Terminbeginn + Termindauer)", () => {
+  it.each([
+    [30, "10:30"],
+    [45, "10:45"],
+    [60, "11:00"],
+    [90, "11:30"],
+    [120, "12:00"],
+    [180, "13:00"],
+  ] as const)(
+    "derives end time for a %i-minute appointment starting at 10:00",
+    (duration, expected) => {
+      expect(addMinutesToTime("10:00", duration)).toBe(expected)
+    }
+  )
+
+  it("covers every documented preset without producing null in a normal day", () => {
+    for (const preset of DURATION_PRESETS) {
+      // Morning appointments never overflow the 23:59 boundary.
+      expect(addMinutesToTime("09:00", preset)).not.toBeNull()
+    }
+  })
+
+  it("handles hour rollover in the derived end time", () => {
+    expect(addMinutesToTime("09:50", 30)).toBe("10:20")
+  })
+
+  it("yields null (empty hidden field) when the appointment overflows midnight", () => {
+    // e.g. a 3h appointment starting at 22:30 -> 01:30 next day is invalid.
+    expect(addMinutesToTime("22:30", 180)).toBeNull()
+  })
+
+  it("returns the start time unchanged for a zero-length duration (no preset)", () => {
+    expect(addMinutesToTime("14:15", 0)).toBe("14:15")
+  })
+})

--- a/src/lib/rides/__tests__/requirements.test.ts
+++ b/src/lib/rides/__tests__/requirements.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest"
+import {
+  requirementsToVehicleType,
+  RIDE_REQUIREMENTS,
+  type RideRequirement,
+} from "@/lib/rides/requirements"
+
+describe("requirementsToVehicleType", () => {
+  it("maps an empty requirement set to standard", () => {
+    expect(requirementsToVehicleType([])).toBe("standard")
+  })
+
+  it("maps a wheelchair requirement to the wheelchair vehicle", () => {
+    expect(requirementsToVehicleType(["wheelchair"])).toBe("wheelchair")
+  })
+
+  it("returns wheelchair when wheelchair is present alongside other requirements", () => {
+    expect(
+      requirementsToVehicleType(["oxygen", "wheelchair", "companion"])
+    ).toBe("wheelchair")
+  })
+
+  it("is order-independent for wheelchair detection", () => {
+    expect(requirementsToVehicleType(["wheelchair", "rollator"])).toBe(
+      "wheelchair"
+    )
+    expect(requirementsToVehicleType(["rollator", "wheelchair"])).toBe(
+      "wheelchair"
+    )
+  })
+
+  it("is unaffected by duplicate wheelchair entries", () => {
+    expect(requirementsToVehicleType(["wheelchair", "wheelchair"])).toBe(
+      "wheelchair"
+    )
+  })
+
+  // Informative-only flags must NOT introduce a non-standard vehicle type.
+  const informativeOnly: RideRequirement[] = [
+    "rollator",
+    "companion",
+    "oxygen",
+    "carry_chair",
+    "stretcher",
+  ]
+
+  it.each(informativeOnly)(
+    "maps the informative-only requirement %s to standard",
+    (requirement) => {
+      expect(requirementsToVehicleType([requirement])).toBe("standard")
+    }
+  )
+
+  it("maps a combination of only informative flags to standard", () => {
+    expect(
+      requirementsToVehicleType(["oxygen", "carry_chair", "stretcher"])
+    ).toBe("standard")
+  })
+
+  it("only ever resolves to existing vehicle_type values (no enum extension)", () => {
+    const allowed = new Set(["standard", "wheelchair"])
+    // Every single requirement, and the full set, must resolve to an allowed
+    // vehicle type -- guards against accidentally returning a new enum value.
+    for (const requirement of RIDE_REQUIREMENTS) {
+      expect(allowed.has(requirementsToVehicleType([requirement]))).toBe(true)
+    }
+    expect(allowed.has(requirementsToVehicleType([...RIDE_REQUIREMENTS]))).toBe(
+      true
+    )
+  })
+})

--- a/src/lib/rides/__tests__/time-buffers.test.ts
+++ b/src/lib/rides/__tests__/time-buffers.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+/**
+ * loadRideTimeBuffers — org-wide buffer loader (Issue #129, M13).
+ *
+ * The pure math lives in `time-calc.ts` (fully covered in time-calc.test.ts);
+ * this loader is the thin I/O layer that reads the singleton
+ * `organization_settings` row and — crucially — must NEVER break ride creation:
+ * on any error or missing row it falls back to the legacy defaults, and any
+ * individual NULL column falls back per-field.
+ *
+ * A stub Supabase client is injected via the optional `client` parameter, so no
+ * real DB or `@/lib/supabase/server` mock is required.
+ */
+
+import {
+  loadRideTimeBuffers,
+  DEFAULT_RIDE_TIME_BUFFERS,
+} from "../time-buffers"
+
+type SingleResult = {
+  data: Record<string, number | null> | null
+  error: { message: string } | null
+}
+
+/** Build a stub client whose `.single()` resolves to the given result. */
+function makeClient(result: SingleResult) {
+  const single = vi.fn().mockResolvedValue(result)
+  const limit = vi.fn().mockReturnValue({ single })
+  const select = vi.fn().mockReturnValue({ limit })
+  const from = vi.fn().mockReturnValue({ select })
+  // Cast through unknown: the loader only ever calls from().select().limit().single().
+  return { client: { from } as unknown as Parameters<typeof loadRideTimeBuffers>[0], from, select }
+}
+
+describe("loadRideTimeBuffers (#129)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("returns the configured buffers when the row is present", async () => {
+    const { client } = makeClient({
+      data: {
+        default_pickup_buffer_minutes: 7,
+        default_boarding_minutes: 4,
+        default_return_buffer_minutes: 25,
+      },
+      error: null,
+    })
+
+    const buffers = await loadRideTimeBuffers(client)
+
+    expect(buffers).toEqual({
+      pickupBufferMinutes: 7,
+      boardingMinutes: 4,
+      returnBufferMinutes: 25,
+    })
+  })
+
+  it("falls back to defaults on a query error (never blocks)", async () => {
+    const { client } = makeClient({
+      data: null,
+      error: { message: "RLS denied" },
+    })
+
+    const buffers = await loadRideTimeBuffers(client)
+
+    expect(buffers).toEqual(DEFAULT_RIDE_TIME_BUFFERS)
+  })
+
+  it("falls back to defaults when no row exists", async () => {
+    const { client } = makeClient({ data: null, error: null })
+
+    const buffers = await loadRideTimeBuffers(client)
+
+    expect(buffers).toEqual(DEFAULT_RIDE_TIME_BUFFERS)
+  })
+
+  it("falls back per-field when individual columns are NULL", async () => {
+    const { client } = makeClient({
+      data: {
+        default_pickup_buffer_minutes: null,
+        default_boarding_minutes: 9,
+        default_return_buffer_minutes: null,
+      },
+      error: null,
+    })
+
+    const buffers = await loadRideTimeBuffers(client)
+
+    expect(buffers).toEqual({
+      pickupBufferMinutes: DEFAULT_RIDE_TIME_BUFFERS.pickupBufferMinutes,
+      boardingMinutes: 9,
+      returnBufferMinutes: DEFAULT_RIDE_TIME_BUFFERS.returnBufferMinutes,
+    })
+  })
+
+  it("exposes defaults matching the legacy hardcoded constants", () => {
+    expect(DEFAULT_RIDE_TIME_BUFFERS).toEqual({
+      pickupBufferMinutes: 5,
+      boardingMinutes: 0,
+      returnBufferMinutes: 15,
+    })
+  })
+
+  it("reads exactly the three buffer columns from organization_settings", async () => {
+    const { client, from, select } = makeClient({
+      data: {
+        default_pickup_buffer_minutes: 5,
+        default_boarding_minutes: 0,
+        default_return_buffer_minutes: 15,
+      },
+      error: null,
+    })
+
+    await loadRideTimeBuffers(client)
+
+    expect(from).toHaveBeenCalledWith("organization_settings")
+    expect(select).toHaveBeenCalledWith(
+      "default_pickup_buffer_minutes, default_boarding_minutes, default_return_buffer_minutes"
+    )
+  })
+})

--- a/src/lib/rides/__tests__/time-calc.test.ts
+++ b/src/lib/rides/__tests__/time-calc.test.ts
@@ -3,6 +3,8 @@ import {
   calculateRideTimes,
   detectTimeConflicts,
   DEFAULT_PICKUP_BUFFER_MINUTES,
+  DEFAULT_BOARDING_MINUTES,
+  DEFAULT_RETURN_BUFFER_MINUTES,
 } from "../time-calc"
 import type { ConflictRideInput } from "../time-calc"
 
@@ -89,6 +91,51 @@ describe("calculateRideTimes", () => {
       // 10:00 - 0min drive - 5min buffer = 09:55
       expect(result.suggestedPickupTime).toBe("09:55")
     })
+
+    it("defaults boardingMinutes to 0 (no behavior change)", () => {
+      const result = calculateRideTimes({
+        appointment_time: "09:30",
+        appointment_end_time: null,
+        duration_seconds: 1200, // 20 minutes
+      })
+      // 09:30 - 20min drive - 5min buffer - 0min boarding = 09:05
+      expect(result.suggestedPickupTime).toBe("09:05")
+    })
+
+    it("subtracts boardingMinutes from the outbound pickup", () => {
+      const result = calculateRideTimes({
+        appointment_time: "09:30",
+        appointment_end_time: null,
+        duration_seconds: 1200, // 20 minutes
+        boardingMinutes: 10,
+      })
+      // 09:30 - 20min drive - 5min buffer - 10min boarding = 08:55
+      expect(result.suggestedPickupTime).toBe("08:55")
+    })
+
+    it("combines custom pickupBufferMinutes and boardingMinutes (org defaults)", () => {
+      const result = calculateRideTimes({
+        appointment_time: "10:00",
+        appointment_end_time: null,
+        duration_seconds: 600, // 10 minutes
+        pickupBufferMinutes: 10,
+        boardingMinutes: 5,
+      })
+      // 10:00 - 10min drive - 10min buffer - 5min boarding = 09:35
+      expect(result.suggestedPickupTime).toBe("09:35")
+    })
+
+    it("returns null when boardingMinutes pushes the pickup before 00:00", () => {
+      const result = calculateRideTimes({
+        appointment_time: "00:20",
+        appointment_end_time: null,
+        duration_seconds: 300, // 5 minutes
+        pickupBufferMinutes: 5,
+        boardingMinutes: 15,
+      })
+      // 00:20 - 5min drive - 5min buffer - 15min boarding = -5min → null
+      expect(result.suggestedPickupTime).toBeNull()
+    })
   })
 
   // -------------------------------------------------------------------------
@@ -172,6 +219,21 @@ describe("calculateRideTimes", () => {
       expect(result.suggestedPickupTime).toBeNull()
       expect(result.suggestedReturnPickupTime).toBeNull()
     })
+
+    it("applies full org buffer set: pickup, boarding and return", () => {
+      const result = calculateRideTimes({
+        appointment_time: "09:00",
+        appointment_end_time: "10:00",
+        duration_seconds: 900, // 15 minutes
+        pickupBufferMinutes: 10,
+        boardingMinutes: 5,
+        returnBufferMinutes: 20,
+      })
+      // Outbound: 09:00 - 15min drive - 10min buffer - 5min boarding = 08:30
+      expect(result.suggestedPickupTime).toBe("08:30")
+      // Return: 10:00 + 20min buffer = 10:20
+      expect(result.suggestedReturnPickupTime).toBe("10:20")
+    })
   })
 
   // -------------------------------------------------------------------------
@@ -181,6 +243,14 @@ describe("calculateRideTimes", () => {
   describe("constants", () => {
     it("exports DEFAULT_PICKUP_BUFFER_MINUTES as 5", () => {
       expect(DEFAULT_PICKUP_BUFFER_MINUTES).toBe(5)
+    })
+
+    it("exports DEFAULT_BOARDING_MINUTES as 0", () => {
+      expect(DEFAULT_BOARDING_MINUTES).toBe(0)
+    })
+
+    it("exports DEFAULT_RETURN_BUFFER_MINUTES as 15", () => {
+      expect(DEFAULT_RETURN_BUFFER_MINUTES).toBe(15)
     })
   })
 })

--- a/src/lib/rides/__tests__/warnings.test.ts
+++ b/src/lib/rides/__tests__/warnings.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest"
+import {
+  collectRideWarnings,
+  RIDE_WARNING_LABELS,
+  type RideWarningInput,
+} from "@/lib/rides/warnings"
+
+const allResolved: RideWarningInput = {
+  patientGeocoded: true,
+  destinationGeocoded: true,
+  priceResolved: true,
+  appointmentTimeSet: true,
+}
+
+describe("collectRideWarnings", () => {
+  it("returns no warnings when everything is resolved", () => {
+    expect(collectRideWarnings(allResolved)).toEqual([])
+  })
+
+  it("warns when the patient is not geocoded", () => {
+    const warnings = collectRideWarnings({
+      ...allResolved,
+      patientGeocoded: false,
+    })
+    expect(warnings).toEqual([
+      {
+        code: "patient_not_geocoded",
+        field: "patient_id",
+        message: RIDE_WARNING_LABELS.patient_not_geocoded,
+      },
+    ])
+  })
+
+  it("warns when the destination is not geocoded", () => {
+    const warnings = collectRideWarnings({
+      ...allResolved,
+      destinationGeocoded: false,
+    })
+    expect(warnings.map((w) => w.code)).toEqual(["destination_not_geocoded"])
+  })
+
+  it("warns when the price could not be resolved", () => {
+    const warnings = collectRideWarnings({
+      ...allResolved,
+      priceResolved: false,
+    })
+    expect(warnings.map((w) => w.code)).toEqual(["price_not_calculated"])
+  })
+
+  it("warns when the appointment time is missing", () => {
+    const warnings = collectRideWarnings({
+      ...allResolved,
+      appointmentTimeSet: false,
+    })
+    expect(warnings.map((w) => w.code)).toEqual(["appointment_time_missing"])
+  })
+
+  it("emits all warnings in a stable order when nothing is resolved", () => {
+    const warnings = collectRideWarnings({
+      patientGeocoded: false,
+      destinationGeocoded: false,
+      priceResolved: false,
+      appointmentTimeSet: false,
+    })
+    expect(warnings.map((w) => w.code)).toEqual([
+      "patient_not_geocoded",
+      "destination_not_geocoded",
+      "price_not_calculated",
+      "appointment_time_missing",
+    ])
+  })
+
+  it("never throws and always returns an array (never blocks)", () => {
+    expect(Array.isArray(collectRideWarnings(allResolved))).toBe(true)
+  })
+})

--- a/src/lib/rides/constants.ts
+++ b/src/lib/rides/constants.ts
@@ -13,6 +13,7 @@
  */
 
 import type { Enums } from "@/lib/types/database"
+import type { RideRequirement } from "@/lib/rides/requirements"
 
 type RideStatus = Enums<"ride_status">
 type RideDirection = Enums<"ride_direction">
@@ -155,6 +156,23 @@ export const IMPAIRMENT_TYPE_LABELS: Record<Enums<"impairment_type">, string> = 
   wheelchair: "Rollstuhl",
   stretcher:  "Liegend",
   companion:  "Begleitperson",
+}
+
+/**
+ * Ride requirement labels in German (Issue #126).
+ *
+ * Keyed by the local `RideRequirement` union (the generated Supabase types do
+ * not know the `ride_requirement` enum yet -- regenerated centrally after the
+ * M13 merge). `oxygen`/`carry_chair` are informative-only flags that do not
+ * affect the vehicle type; see `src/lib/rides/requirements.ts`.
+ */
+export const RIDE_REQUIREMENT_LABELS: Record<RideRequirement, string> = {
+  wheelchair:  "Rollstuhl",
+  rollator:    "Rollator",
+  companion:   "Begleitung",
+  oxygen:      "Sauerstoff",
+  carry_chair: "Tragestuhl",
+  stretcher:   "Liegend",
 }
 
 /** Absence type labels in German (driver_absences, Issue #104). */

--- a/src/lib/rides/requirements.ts
+++ b/src/lib/rides/requirements.ts
@@ -21,33 +21,23 @@
  * This module has no DB/React/Next dependencies so it can be unit-tested in
  * isolation, mirroring the style of `src/lib/availability/resolve.ts`.
  *
- * Type note: the generated Supabase types do not know the `ride_requirement`
- * enum yet (they are regenerated centrally after the M13 merge). Until then this
- * module owns the canonical `RideRequirement` union; it MUST stay in sync with
- * the enum defined in `supabase/migrations/20260328_000001_ride_requirements.sql`.
- * `VehicleType` is taken from the generated types, which already know it.
+ * Type note: `RIDE_REQUIREMENTS` is the canonical, ordered source of truth for
+ * the `RideRequirement` union and drives the Zod enum in
+ * `src/lib/validations/rides.ts`. It MUST stay in lockstep with the
+ * `public.ride_requirement` Postgres enum
+ * (`supabase/migrations/20260716_000001_ride_requirements.sql`). The generated
+ * Supabase types now know that enum; `_RequirementsMatchEnum` below asserts at
+ * compile time that this list and the DB enum are identical.
+ * `VehicleType` is taken from the generated types.
  */
 
 import type { Enums } from "@/lib/types/database"
 
 /**
- * The set of transport requirements a ride can carry. Kept in lockstep with the
- * `public.ride_requirement` Postgres enum. Once the generated types include the
- * enum, this can be replaced by `Enums<"ride_requirement">`.
+ * Ordered list of all requirement values -- the single source of truth for both
+ * the `RideRequirement` union and the runtime Zod whitelist (#126, #135).
  */
-export type RideRequirement =
-  | "wheelchair"
-  | "rollator"
-  | "companion"
-  | "oxygen"
-  | "carry_chair"
-  | "stretcher"
-
-/** Vehicle type as defined by the DB enum (not extended in M13). */
-export type VehicleType = Enums<"vehicle_type">
-
-/** Ordered list of all requirement values, useful for UI/iteration (#135). */
-export const RIDE_REQUIREMENTS: readonly RideRequirement[] = [
+export const RIDE_REQUIREMENTS = [
   "wheelchair",
   "rollator",
   "companion",
@@ -55,6 +45,32 @@ export const RIDE_REQUIREMENTS: readonly RideRequirement[] = [
   "carry_chair",
   "stretcher",
 ] as const
+
+/**
+ * The set of transport requirements a ride can carry. Derived from
+ * {@link RIDE_REQUIREMENTS} and kept in lockstep with the
+ * `public.ride_requirement` Postgres enum.
+ */
+export type RideRequirement = (typeof RIDE_REQUIREMENTS)[number]
+
+/** Vehicle type as defined by the DB enum (not extended in M13). */
+export type VehicleType = Enums<"vehicle_type">
+
+/**
+ * Compile-time guarantee that the local list matches the DB enum exactly (both
+ * directions). `Assert<T extends true>` fails to typecheck if the condition is
+ * `false`, so any divergence between this list and the migration is a build
+ * error. Purely a type-level assertion -- no runtime footprint.
+ */
+type Assert<T extends true> = T
+export type _RequirementsMatchEnum = Assert<
+  [RideRequirement] extends [Enums<"ride_requirement">]
+    ? [Enums<"ride_requirement">] extends [RideRequirement]
+      ? true
+      : false
+    : false
+>
+
 
 /**
  * Derive the required `vehicle_type` from a set of ride requirements.

--- a/src/lib/rides/requirements.ts
+++ b/src/lib/rides/requirements.ts
@@ -1,0 +1,73 @@
+/**
+ * Ride requirements -> vehicle type mapping (Issue #126).
+ *
+ * Pure, UI-independent logic that answers a single question:
+ * "Given the transport requirements captured on a ride, which vehicle_type does
+ * it need?"
+ *
+ * Scope decisions (#126):
+ *  - The `ride_requirement` set is a superset of `impairment_type`
+ *    (rollator/wheelchair/stretcher/companion) plus `oxygen` and `carry_chair`.
+ *  - `vehicle_type` is NOT extended in M13. Only `wheelchair` maps to a
+ *    dedicated vehicle type; every other requirement -- including `oxygen`,
+ *    `carry_chair`, `rollator`, `companion` and `stretcher` -- is treated as an
+ *    informative flag and does NOT influence the vehicle type. It therefore
+ *    resolves to `standard`.
+ *  - `stretcher` deliberately maps to `standard` here even though a `stretcher`
+ *    vehicle_type value exists: dedicated stretcher-vehicle selection is out of
+ *    scope for M13 and the mapping spec is explicitly "wheelchair -> wheelchair,
+ *    otherwise standard".
+ *
+ * This module has no DB/React/Next dependencies so it can be unit-tested in
+ * isolation, mirroring the style of `src/lib/availability/resolve.ts`.
+ *
+ * Type note: the generated Supabase types do not know the `ride_requirement`
+ * enum yet (they are regenerated centrally after the M13 merge). Until then this
+ * module owns the canonical `RideRequirement` union; it MUST stay in sync with
+ * the enum defined in `supabase/migrations/20260328_000001_ride_requirements.sql`.
+ * `VehicleType` is taken from the generated types, which already know it.
+ */
+
+import type { Enums } from "@/lib/types/database"
+
+/**
+ * The set of transport requirements a ride can carry. Kept in lockstep with the
+ * `public.ride_requirement` Postgres enum. Once the generated types include the
+ * enum, this can be replaced by `Enums<"ride_requirement">`.
+ */
+export type RideRequirement =
+  | "wheelchair"
+  | "rollator"
+  | "companion"
+  | "oxygen"
+  | "carry_chair"
+  | "stretcher"
+
+/** Vehicle type as defined by the DB enum (not extended in M13). */
+export type VehicleType = Enums<"vehicle_type">
+
+/** Ordered list of all requirement values, useful for UI/iteration (#135). */
+export const RIDE_REQUIREMENTS: readonly RideRequirement[] = [
+  "wheelchair",
+  "rollator",
+  "companion",
+  "oxygen",
+  "carry_chair",
+  "stretcher",
+] as const
+
+/**
+ * Derive the required `vehicle_type` from a set of ride requirements.
+ *
+ * Mapping (M13): a `wheelchair` requirement needs a `wheelchair` vehicle; every
+ * other requirement is informative only and resolves to `standard`. The input
+ * order and duplicates do not matter.
+ *
+ * @param requirements The ride's requirements (may be empty).
+ * @returns `"wheelchair"` if wheelchair transport is required, else `"standard"`.
+ */
+export function requirementsToVehicleType(
+  requirements: readonly RideRequirement[]
+): VehicleType {
+  return requirements.includes("wheelchair") ? "wheelchair" : "standard"
+}

--- a/src/lib/rides/time-buffers.ts
+++ b/src/lib/rides/time-buffers.ts
@@ -1,0 +1,77 @@
+/**
+ * Ride time-buffer loader (Issue #129).
+ *
+ * Server-side glue that reads the organization-wide time-buffer defaults
+ * (Issue #128) from `organization_settings` and hands them to the pure
+ * `calculateRideTimes` function in `./time-calc`. Keeping the I/O here keeps
+ * the calculation itself side-effect free and unit-testable (same split as
+ * `resolveAvailability` vs. its loaders).
+ *
+ * The buffers are org-wide defaults, not per-ride values: they only seed the
+ * overridable pickup-time suggestion.
+ */
+
+import { createClient } from "@/lib/supabase/server"
+import {
+  DEFAULT_PICKUP_BUFFER_MINUTES,
+  DEFAULT_BOARDING_MINUTES,
+  DEFAULT_RETURN_BUFFER_MINUTES,
+} from "@/lib/validations/rides"
+
+/** Client type accepted by the loader (awaited server Supabase client). */
+type ServerClient = Awaited<ReturnType<typeof createClient>>
+
+/** Resolved org-wide time buffers used to seed pickup-time suggestions. */
+export interface RideTimeBuffers {
+  /** Minutes subtracted before the drive duration (driver approach lead time). */
+  pickupBufferMinutes: number
+  /** Minutes reserved for boarding/alighting at the patient. */
+  boardingMinutes: number
+  /** Minutes added after appointment end for the return pickup. */
+  returnBufferMinutes: number
+}
+
+/**
+ * Fallback buffers matching the legacy hardcoded constants. Used whenever the
+ * organization settings cannot be loaded so ride creation never breaks.
+ */
+export const DEFAULT_RIDE_TIME_BUFFERS: RideTimeBuffers = {
+  pickupBufferMinutes: DEFAULT_PICKUP_BUFFER_MINUTES,
+  boardingMinutes: DEFAULT_BOARDING_MINUTES,
+  returnBufferMinutes: DEFAULT_RETURN_BUFFER_MINUTES,
+}
+
+/**
+ * Load the organization-wide time-buffer defaults.
+ *
+ * Reads the singleton `organization_settings` row. On any error (missing row,
+ * RLS, etc.) it falls back to {@link DEFAULT_RIDE_TIME_BUFFERS} so callers can
+ * always rely on a usable result. Pass an existing server client to avoid a
+ * redundant client creation inside a Server Action.
+ */
+export async function loadRideTimeBuffers(
+  client?: ServerClient
+): Promise<RideTimeBuffers> {
+  const supabase = client ?? (await createClient())
+
+  const { data, error } = await supabase
+    .from("organization_settings")
+    .select(
+      "default_pickup_buffer_minutes, default_boarding_minutes, default_return_buffer_minutes"
+    )
+    .limit(1)
+    .single()
+
+  if (error || !data) {
+    return DEFAULT_RIDE_TIME_BUFFERS
+  }
+
+  return {
+    pickupBufferMinutes:
+      data.default_pickup_buffer_minutes ?? DEFAULT_PICKUP_BUFFER_MINUTES,
+    boardingMinutes:
+      data.default_boarding_minutes ?? DEFAULT_BOARDING_MINUTES,
+    returnBufferMinutes:
+      data.default_return_buffer_minutes ?? DEFAULT_RETURN_BUFFER_MINUTES,
+  }
+}

--- a/src/lib/rides/time-calc.ts
+++ b/src/lib/rides/time-calc.ts
@@ -11,10 +11,15 @@ import {
   addMinutesToTime,
   subtractMinutesFromTime,
   DEFAULT_PICKUP_BUFFER_MINUTES,
+  DEFAULT_BOARDING_MINUTES,
   DEFAULT_RETURN_BUFFER_MINUTES,
 } from "@/lib/validations/rides"
 
-export { DEFAULT_PICKUP_BUFFER_MINUTES }
+export {
+  DEFAULT_PICKUP_BUFFER_MINUTES,
+  DEFAULT_BOARDING_MINUTES,
+  DEFAULT_RETURN_BUFFER_MINUTES,
+}
 
 export interface RideTimeCalcInputs {
   /** Appointment start time in "HH:MM" format, or null if unknown */
@@ -25,6 +30,12 @@ export interface RideTimeCalcInputs {
   duration_seconds: number | null
   /** Buffer minutes before drive duration (default: DEFAULT_PICKUP_BUFFER_MINUTES) */
   pickupBufferMinutes?: number
+  /**
+   * Boarding time in minutes reserved at the patient for boarding/alighting.
+   * Added to the outbound back-calculation so the driver arrives early enough
+   * to complete boarding before the appointment (default: DEFAULT_BOARDING_MINUTES).
+   */
+  boardingMinutes?: number
   /** Buffer minutes after appointment end for return pickup (default: DEFAULT_RETURN_BUFFER_MINUTES) */
   returnBufferMinutes?: number
 }
@@ -39,7 +50,7 @@ export interface RideTimeCalcResult {
 /**
  * Calculate suggested pickup times for a ride.
  *
- * Outbound: appointment_time - ceil(duration_seconds / 60) - pickupBufferMinutes
+ * Outbound: appointment_time - ceil(duration_seconds / 60) - pickupBufferMinutes - boardingMinutes
  * Return:   appointment_end_time + returnBufferMinutes
  *
  * Returns null for either value if the required inputs are missing
@@ -51,13 +62,15 @@ export function calculateRideTimes(inputs: RideTimeCalcInputs): RideTimeCalcResu
     appointment_end_time,
     duration_seconds,
     pickupBufferMinutes = DEFAULT_PICKUP_BUFFER_MINUTES,
+    boardingMinutes = DEFAULT_BOARDING_MINUTES,
     returnBufferMinutes = DEFAULT_RETURN_BUFFER_MINUTES,
   } = inputs
 
   const suggestedPickupTime = calculateOutboundPickup(
     appointment_time,
     duration_seconds,
-    pickupBufferMinutes
+    pickupBufferMinutes,
+    boardingMinutes
   )
 
   const suggestedReturnPickupTime = calculateReturnPickup(
@@ -70,19 +83,20 @@ export function calculateRideTimes(inputs: RideTimeCalcInputs): RideTimeCalcResu
 
 /**
  * Calculate outbound pickup time.
- * appointment_time - ceil(duration_seconds / 60) - bufferMinutes
+ * appointment_time - ceil(duration_seconds / 60) - bufferMinutes - boardingMinutes
  */
 function calculateOutboundPickup(
   appointmentTime: string | null,
   durationSeconds: number | null,
-  bufferMinutes: number
+  bufferMinutes: number,
+  boardingMinutes: number
 ): string | null {
   if (appointmentTime === null || durationSeconds === null) {
     return null
   }
 
   const durationMinutes = Math.ceil(durationSeconds / 60)
-  const totalMinutesToSubtract = durationMinutes + bufferMinutes
+  const totalMinutesToSubtract = durationMinutes + bufferMinutes + boardingMinutes
 
   return subtractMinutesFromTime(appointmentTime, totalMinutesToSubtract)
 }

--- a/src/lib/rides/warnings.ts
+++ b/src/lib/rides/warnings.ts
@@ -1,0 +1,87 @@
+/**
+ * Ride persistence warnings (Issue #130).
+ *
+ * "Never block" principle: creating or updating a ride must never fail because
+ * geocoding, route/price calculation or an appointment time is missing. Those
+ * situations are surfaced as structured, non-blocking warnings instead of hard
+ * field errors, so the dispatcher can save now and fix later. The capture UI
+ * that renders these warnings is #139; this module only owns their shape and a
+ * pure collector so it can be unit-tested in isolation (no DB/React/Next deps).
+ */
+
+import type { ActionWarning } from "@/actions/shared"
+
+/** Stable, whitelisted warning codes for ride persistence. */
+export type RideWarningCode =
+  | "patient_not_geocoded"
+  | "destination_not_geocoded"
+  | "price_not_calculated"
+  | "appointment_time_missing"
+
+/** German fallback copy per warning code. */
+export const RIDE_WARNING_LABELS: Record<RideWarningCode, string> = {
+  patient_not_geocoded:
+    "Die Patientenadresse ist noch nicht geocodiert. Route und Preis konnten nicht berechnet werden.",
+  destination_not_geocoded:
+    "Die Zieladresse ist noch nicht geocodiert. Route und Preis konnten nicht berechnet werden.",
+  price_not_calculated:
+    "Der Preis konnte nicht automatisch berechnet werden. Bitte spaeter pruefen oder manuell erfassen.",
+  appointment_time_missing:
+    "Es ist kein Terminbeginn erfasst. Abholzeit-Vorschlaege stehen daher nicht zur Verfuegung.",
+}
+
+/** Inputs describing what could (not) be resolved while persisting a ride. */
+export interface RideWarningInput {
+  /** Patient has usable lat/lng. */
+  patientGeocoded: boolean
+  /** Destination has usable lat/lng. */
+  destinationGeocoded: boolean
+  /** A price is present -- either auto-calculated or a manual override. */
+  priceResolved: boolean
+  /**
+   * An appointment start time is set (or not applicable, e.g. return rides).
+   * Callers pass `true` when the field does not apply to skip the warning.
+   */
+  appointmentTimeSet: boolean
+}
+
+/**
+ * Derive the set of non-blocking warnings for a ride save. Pure and
+ * order-stable: geocoding first, then price, then appointment.
+ */
+export function collectRideWarnings(input: RideWarningInput): ActionWarning[] {
+  const warnings: ActionWarning[] = []
+
+  if (!input.patientGeocoded) {
+    warnings.push({
+      code: "patient_not_geocoded",
+      field: "patient_id",
+      message: RIDE_WARNING_LABELS.patient_not_geocoded,
+    })
+  }
+
+  if (!input.destinationGeocoded) {
+    warnings.push({
+      code: "destination_not_geocoded",
+      field: "destination_id",
+      message: RIDE_WARNING_LABELS.destination_not_geocoded,
+    })
+  }
+
+  if (!input.priceResolved) {
+    warnings.push({
+      code: "price_not_calculated",
+      message: RIDE_WARNING_LABELS.price_not_calculated,
+    })
+  }
+
+  if (!input.appointmentTimeSet) {
+    warnings.push({
+      code: "appointment_time_missing",
+      field: "appointment_time",
+      message: RIDE_WARNING_LABELS.appointment_time_missing,
+    })
+  }
+
+  return warnings
+}

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -587,6 +587,9 @@ export type Database = {
       organization_settings: {
         Row: {
           created_at: string
+          default_boarding_minutes: number
+          default_pickup_buffer_minutes: number
+          default_return_buffer_minutes: number
           email_enabled: boolean
           email_from_address: string | null
           email_from_name: string | null
@@ -607,6 +610,9 @@ export type Database = {
         }
         Insert: {
           created_at?: string
+          default_boarding_minutes?: number
+          default_pickup_buffer_minutes?: number
+          default_return_buffer_minutes?: number
           email_enabled?: boolean
           email_from_address?: string | null
           email_from_name?: string | null
@@ -627,6 +633,9 @@ export type Database = {
         }
         Update: {
           created_at?: string
+          default_boarding_minutes?: number
+          default_pickup_buffer_minutes?: number
+          default_return_buffer_minutes?: number
           email_enabled?: boolean
           email_from_address?: string | null
           email_from_name?: string | null
@@ -680,6 +689,7 @@ export type Database = {
         Row: {
           city: string | null
           comment: string | null
+          cost_bearer: Database["public"]["Enums"]["cost_bearer_type"] | null
           created_at: string
           emergency_contact_name: string | null
           emergency_contact_phone: string | null
@@ -704,6 +714,7 @@ export type Database = {
         Insert: {
           city?: string | null
           comment?: string | null
+          cost_bearer?: Database["public"]["Enums"]["cost_bearer_type"] | null
           created_at?: string
           emergency_contact_name?: string | null
           emergency_contact_phone?: string | null
@@ -728,6 +739,7 @@ export type Database = {
         Update: {
           city?: string | null
           comment?: string | null
+          cost_bearer?: Database["public"]["Enums"]["cost_bearer_type"] | null
           created_at?: string
           emergency_contact_name?: string | null
           emergency_contact_phone?: string | null
@@ -890,6 +902,7 @@ export type Database = {
           polyline: string | null
           price_override: number | null
           price_override_reason: string | null
+          requirements: Database["public"]["Enums"]["ride_requirement"][]
           return_pickup_time: string | null
           ride_series_id: string | null
           status: Database["public"]["Enums"]["ride_status"]
@@ -924,6 +937,7 @@ export type Database = {
           polyline?: string | null
           price_override?: number | null
           price_override_reason?: string | null
+          requirements?: Database["public"]["Enums"]["ride_requirement"][]
           return_pickup_time?: string | null
           ride_series_id?: string | null
           status?: Database["public"]["Enums"]["ride_status"]
@@ -958,6 +972,7 @@ export type Database = {
           polyline?: string | null
           price_override?: number | null
           price_override_reason?: string | null
+          requirements?: Database["public"]["Enums"]["ride_requirement"][]
           return_pickup_time?: string | null
           ride_series_id?: string | null
           status?: Database["public"]["Enums"]["ride_status"]
@@ -1125,6 +1140,11 @@ export type Database = {
         | "confirmed"
         | "rejected"
         | "cancelled"
+      cost_bearer_type:
+        | "health_insurance"
+        | "self_payer"
+        | "municipality"
+        | "other"
       day_of_week:
         | "monday"
         | "tuesday"
@@ -1153,6 +1173,13 @@ export type Database = {
         | "dispatcher_override"
         | "timeout"
       ride_direction: "outbound" | "return" | "both"
+      ride_requirement:
+        | "wheelchair"
+        | "rollator"
+        | "companion"
+        | "oxygen"
+        | "carry_chair"
+        | "stretcher"
       ride_status:
         | "unplanned"
         | "planned"
@@ -1304,6 +1331,12 @@ export const Constants = {
         "rejected",
         "cancelled",
       ],
+      cost_bearer_type: [
+        "health_insurance",
+        "self_payer",
+        "municipality",
+        "other",
+      ],
       day_of_week: [
         "monday",
         "tuesday",
@@ -1336,6 +1369,14 @@ export const Constants = {
         "timeout",
       ],
       ride_direction: ["outbound", "return", "both"],
+      ride_requirement: [
+        "wheelchair",
+        "rollator",
+        "companion",
+        "oxygen",
+        "carry_chair",
+        "stretcher",
+      ],
       ride_status: [
         "unplanned",
         "planned",

--- a/src/lib/validations/__tests__/organization.test.ts
+++ b/src/lib/validations/__tests__/organization.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest"
+import { updateOrganizationSchema } from "../organization"
+
+/**
+ * Time-buffer defaults on organization_settings (Issue #128, M13).
+ *
+ * These org-wide buffers seed the pickup-time suggestion in the capture page
+ * (feeding `loadRideTimeBuffers` -> `calculateRideTimes`). The Zod schema is the
+ * boundary that turns raw FormData strings into clamped integers, mirroring the
+ * 0-120 CHECK constraint in the migration. Tested through the full
+ * `updateOrganizationSchema` because `bufferMinutes` is a private factory.
+ */
+
+const validBase = {
+  org_name: "Fahrdienst Test",
+  primary_color: "#000000",
+  secondary_color: "#0066FF",
+  email_from_name: "Fahrdienst",
+}
+
+describe("updateOrganizationSchema — time buffers (#128)", () => {
+  it("applies the legacy defaults when the buffer fields are omitted", () => {
+    const result = updateOrganizationSchema.safeParse(validBase)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.default_pickup_buffer_minutes).toBe(5)
+      expect(result.data.default_boarding_minutes).toBe(0)
+      expect(result.data.default_return_buffer_minutes).toBe(15)
+    }
+  })
+
+  it("coerces string FormData values to integers", () => {
+    const result = updateOrganizationSchema.safeParse({
+      ...validBase,
+      default_pickup_buffer_minutes: "10",
+      default_boarding_minutes: "8",
+      default_return_buffer_minutes: "20",
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.default_pickup_buffer_minutes).toBe(10)
+      expect(result.data.default_boarding_minutes).toBe(8)
+      expect(result.data.default_return_buffer_minutes).toBe(20)
+    }
+  })
+
+  it("accepts the boundary values 0 and 120", () => {
+    const result = updateOrganizationSchema.safeParse({
+      ...validBase,
+      default_pickup_buffer_minutes: "0",
+      default_boarding_minutes: "120",
+      default_return_buffer_minutes: "0",
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.default_pickup_buffer_minutes).toBe(0)
+      expect(result.data.default_boarding_minutes).toBe(120)
+    }
+  })
+
+  it("rejects a negative buffer", () => {
+    const result = updateOrganizationSchema.safeParse({
+      ...validBase,
+      default_pickup_buffer_minutes: "-1",
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) =>
+          i.path.includes("default_pickup_buffer_minutes")
+        )
+      ).toBe(true)
+    }
+  })
+
+  it("rejects a buffer above 120", () => {
+    const result = updateOrganizationSchema.safeParse({
+      ...validBase,
+      default_return_buffer_minutes: "121",
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) =>
+          i.path.includes("default_return_buffer_minutes")
+        )
+      ).toBe(true)
+    }
+  })
+
+  it("rejects a non-integer buffer", () => {
+    const result = updateOrganizationSchema.safeParse({
+      ...validBase,
+      default_boarding_minutes: "5.5",
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects a non-numeric buffer string", () => {
+    const result = updateOrganizationSchema.safeParse({
+      ...validBase,
+      default_pickup_buffer_minutes: "abc",
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/lib/validations/__tests__/patients-cost-bearer.test.ts
+++ b/src/lib/validations/__tests__/patients-cost-bearer.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest"
+import { patientSchema, patientInlineSchema } from "../patients"
+import { COST_BEARER_VALUES, COST_BEARER_NONE } from "@/lib/patients/constants"
+
+/**
+ * Kostenträger (cost bearer) boundary validation (Issue #125, M13).
+ *
+ * The <Select> in the patient form submits either an enum value, an empty
+ * string, or the "__none__" sentinel. All non-values must collapse to `null`
+ * (cost bearer is optional and lives on the patient, never on the ride). The
+ * enum whitelist must reject anything outside `COST_BEARER_VALUES`.
+ *
+ * Covered through both `patientSchema` (full form #134) and
+ * `patientInlineSchema` (inline quick-create #137), since the cost-bearer field
+ * is shared between them.
+ */
+
+const validPatientBase = {
+  first_name: "Anna",
+  last_name: "Muster",
+  street: "Bahnhofstrasse",
+  house_number: "1",
+  postal_code: "8600",
+  city: "Dübendorf",
+}
+
+describe("cost_bearer field (#125)", () => {
+  describe("patientSchema (full form)", () => {
+    it("maps an empty string to null", () => {
+      const result = patientSchema.safeParse({
+        ...validPatientBase,
+        cost_bearer: "",
+      })
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data.cost_bearer).toBeNull()
+    })
+
+    it("maps the __none__ sentinel to null", () => {
+      const result = patientSchema.safeParse({
+        ...validPatientBase,
+        cost_bearer: COST_BEARER_NONE,
+      })
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data.cost_bearer).toBeNull()
+    })
+
+    it("maps an omitted cost_bearer to null", () => {
+      const result = patientSchema.safeParse(validPatientBase)
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data.cost_bearer).toBeNull()
+    })
+
+    it.each(COST_BEARER_VALUES)(
+      "accepts the whitelisted value %s",
+      (value) => {
+        const result = patientSchema.safeParse({
+          ...validPatientBase,
+          cost_bearer: value,
+        })
+        expect(result.success).toBe(true)
+        if (result.success) expect(result.data.cost_bearer).toBe(value)
+      }
+    )
+
+    it("rejects a value outside the enum", () => {
+      const result = patientSchema.safeParse({
+        ...validPatientBase,
+        cost_bearer: "credit_card",
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(
+          result.error.issues.some((i) => i.path.includes("cost_bearer"))
+        ).toBe(true)
+      }
+    })
+  })
+
+  describe("patientInlineSchema (inline quick-create)", () => {
+    it("maps the __none__ sentinel to null", () => {
+      const result = patientInlineSchema.safeParse({
+        ...validPatientBase,
+        cost_bearer: COST_BEARER_NONE,
+      })
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data.cost_bearer).toBeNull()
+    })
+
+    it("accepts a valid enum value", () => {
+      const result = patientInlineSchema.safeParse({
+        ...validPatientBase,
+        cost_bearer: "municipality",
+      })
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data.cost_bearer).toBe("municipality")
+    })
+
+    it("rejects a value outside the enum", () => {
+      const result = patientInlineSchema.safeParse({
+        ...validPatientBase,
+        cost_bearer: "cash",
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  it("exposes exactly the four documented cost-bearer values", () => {
+    expect([...COST_BEARER_VALUES]).toEqual([
+      "health_insurance",
+      "self_payer",
+      "municipality",
+      "other",
+    ])
+  })
+})

--- a/src/lib/validations/__tests__/ride-requirements-schema.test.ts
+++ b/src/lib/validations/__tests__/ride-requirements-schema.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest"
+import {
+  rideRequirementSchema,
+  rideRequirementsSchema,
+} from "../rides"
+import { RIDE_REQUIREMENTS } from "@/lib/rides/requirements"
+
+/**
+ * Bedarf (ride requirements) boundary schemas (Issue #126, M13).
+ *
+ * `src/lib/validations/__tests__/rides.test.ts` exercises requirements through
+ * the full `rideSchema`. This file covers the two exported building blocks
+ * directly — the single-value enum and the set schema with its empty-array
+ * default — because they are the runtime whitelist that keeps the
+ * `ride_requirement[]` column well-defined even for rides created outside the
+ * capture UI (#135).
+ */
+
+describe("rideRequirementSchema (single value)", () => {
+  it.each(RIDE_REQUIREMENTS)("accepts the whitelisted value %s", (value) => {
+    expect(rideRequirementSchema.safeParse(value).success).toBe(true)
+  })
+
+  it("rejects a value outside the enum", () => {
+    expect(rideRequirementSchema.safeParse("teleport").success).toBe(false)
+  })
+
+  it("rejects a non-string value", () => {
+    expect(rideRequirementSchema.safeParse(42).success).toBe(false)
+  })
+})
+
+describe("rideRequirementsSchema (set)", () => {
+  it("defaults to an empty array when the value is omitted", () => {
+    const result = rideRequirementsSchema.safeParse(undefined)
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data).toEqual([])
+  })
+
+  it("accepts an empty array", () => {
+    const result = rideRequirementsSchema.safeParse([])
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data).toEqual([])
+  })
+
+  it("accepts the full requirement set", () => {
+    const result = rideRequirementsSchema.safeParse([...RIDE_REQUIREMENTS])
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data).toEqual([...RIDE_REQUIREMENTS])
+  })
+
+  it("preserves order and duplicates (dedup is a downstream concern)", () => {
+    const result = rideRequirementsSchema.safeParse([
+      "wheelchair",
+      "wheelchair",
+      "oxygen",
+    ])
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual(["wheelchair", "wheelchair", "oxygen"])
+    }
+  })
+
+  it("rejects the whole set if a single member is invalid", () => {
+    const result = rideRequirementsSchema.safeParse(["wheelchair", "unicorn"])
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/lib/validations/__tests__/rides.test.ts
+++ b/src/lib/validations/__tests__/rides.test.ts
@@ -387,6 +387,44 @@ describe("rideSchema", () => {
       expect(result.data.price_override_reason).toBe("Sondertarif vereinbart")
     }
   })
+
+  // --- Requirements (Issue #126/#130) ---
+
+  it("defaults requirements to an empty array when omitted", () => {
+    const result = rideSchema.safeParse(validRide)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.requirements).toEqual([])
+    }
+  })
+
+  it("accepts a whitelisted set of requirements", () => {
+    const result = rideSchema.safeParse({
+      ...validRide,
+      requirements: ["wheelchair", "oxygen", "companion"],
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.requirements).toEqual([
+        "wheelchair",
+        "oxygen",
+        "companion",
+      ])
+    }
+  })
+
+  it("rejects a requirement value outside the enum", () => {
+    const result = rideSchema.safeParse({
+      ...validRide,
+      requirements: ["wheelchair", "teleport"],
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) => i.path.includes("requirements"))
+      ).toBe(true)
+    }
+  })
 })
 
 // --- addMinutesToTime helper ---

--- a/src/lib/validations/organization.ts
+++ b/src/lib/validations/organization.ts
@@ -2,6 +2,20 @@ import { z } from "zod"
 
 const emptyToNull = (v: string) => (v === "" ? null : v)
 
+/**
+ * Time-buffer default (minutes), configurable per organization (Issue #128).
+ * FormData delivers strings, so coerce to an integer and clamp to a sane
+ * range. 0-120 mirrors the CHECK constraint in
+ * supabase/migrations/20260329_000001_org_settings_time_buffers.sql.
+ */
+const bufferMinutes = (fallback: number) =>
+  z.coerce
+    .number({ invalid_type_error: "Ganzzahl erforderlich" })
+    .int("Ganzzahl erforderlich")
+    .min(0, "Mindestens 0 Minuten")
+    .max(120, "Maximal 120 Minuten")
+    .default(fallback)
+
 export const updateOrganizationSchema = z.object({
   org_name: z.string().min(1, "Organisationsname ist erforderlich").max(200),
   org_street: z.string().transform(emptyToNull).nullable().optional(),
@@ -51,6 +65,10 @@ export const updateOrganizationSchema = z.object({
     .nullable()
     .optional()
     .pipe(z.string().email("Ungültige E-Mail-Adresse").nullable().optional()),
+  // Zeit-Puffer-Defaults (Issue #128) — Defaults = bisherige Konstanten.
+  default_pickup_buffer_minutes: bufferMinutes(5),
+  default_boarding_minutes: bufferMinutes(0),
+  default_return_buffer_minutes: bufferMinutes(15),
 })
 
 export type UpdateOrganizationFormValues = z.infer<

--- a/src/lib/validations/patients.ts
+++ b/src/lib/validations/patients.ts
@@ -1,6 +1,16 @@
 import { z } from "zod"
+import { COST_BEARER_VALUES, COST_BEARER_NONE } from "@/lib/patients/constants"
 
 const emptyToNull = (v: string) => (v === "" ? null : v)
+
+/**
+ * Cost bearer (#125). Optional. The <Select> submits either an enum value, an
+ * empty string, or the "__none__" sentinel — all of the latter map to null.
+ */
+const costBearerField = z.preprocess(
+  (v) => (v === "" || v === COST_BEARER_NONE || v === undefined ? null : v),
+  z.enum(COST_BEARER_VALUES).nullable()
+)
 
 export const patientSchema = z.object({
   first_name: z.string().min(1, "Vorname ist erforderlich").max(100),
@@ -36,6 +46,7 @@ export const patientSchema = z.object({
     .transform(emptyToNull)
     .nullable()
     .optional(),
+  cost_bearer: costBearerField,
   impairments: z
     .array(z.enum(["rollator", "wheelchair", "stretcher", "companion"]))
     .default([]),
@@ -66,6 +77,7 @@ export const patientInlineSchema = z.object({
     .min(1, "PLZ ist erforderlich")
     .regex(/^\d{4}$/, "PLZ muss 4-stellig sein (CH)"),
   city: z.string().min(1, "Ort ist erforderlich").max(100),
+  cost_bearer: costBearerField,
 })
 
 export type PatientInlineFormValues = z.infer<typeof patientInlineSchema>

--- a/src/lib/validations/rides.ts
+++ b/src/lib/validations/rides.ts
@@ -15,6 +15,13 @@ export const DEFAULT_RETURN_BUFFER_MINUTES = 15
 export const DEFAULT_PICKUP_BUFFER_MINUTES = 5
 
 /**
+ * Default boarding time (minutes) for the patient to board/alight at pickup.
+ * Added to the outbound back-calculation so the driver arrives early enough
+ * for boarding before the appointment. 0 preserves the legacy behavior.
+ */
+export const DEFAULT_BOARDING_MINUTES = 0
+
+/**
  * Adds minutes to a time string (HH:MM format).
  * Returns null if the result exceeds 23:59.
  */

--- a/src/lib/validations/rides.ts
+++ b/src/lib/validations/rides.ts
@@ -1,6 +1,24 @@
 import { z } from "zod"
+import { RIDE_REQUIREMENTS } from "@/lib/rides/requirements"
 
 const emptyToNull = (v: string) => (v === "" || v === "__none__" ? null : v)
+
+/**
+ * Runtime whitelist for a single ride requirement (Issue #126). Enum-based, so
+ * any value outside the `ride_requirement` set is rejected at the boundary.
+ */
+export const rideRequirementSchema = z.enum(RIDE_REQUIREMENTS)
+
+/**
+ * Set of requirements for a ride. Defaults to an empty array so rides created
+ * without the (#135) capture UI stay well-defined -- matching the NOT NULL
+ * DEFAULT '{}' column. Order/duplicates are irrelevant downstream
+ * (see requirementsToVehicleType).
+ */
+export const rideRequirementsSchema = z
+  .array(rideRequirementSchema)
+  .optional()
+  .default([])
 
 /**
  * Default buffer (minutes) between appointment_end_time and return_pickup_time.
@@ -94,6 +112,8 @@ export const rideSchema = z
       .transform(emptyToNull)
       .nullable()
       .optional(),
+    // --- Transport requirements (ride level, Issue #126) ---
+    requirements: rideRequirementsSchema,
     // --- Duebendorf tariff fields ---
     duration_category: z
       .enum(["under_2h", "over_2h"])

--- a/supabase/migrations/20260715_000001_patient_cost_bearer.sql
+++ b/supabase/migrations/20260715_000001_patient_cost_bearer.sql
@@ -1,0 +1,49 @@
+-- Migration: Kostenträger (cost bearer) on the patient
+-- Issue #125 (part of #124), design decision #11.
+--
+-- Cost bearer is tracked ONLY on the patient, never on the ride. This is a pure
+-- schema change; capture/editing happens through the existing patient forms
+-- (#137 / #134).
+--
+-- Idempotent: safe to re-run.
+
+-- -----------------------------------------------------------------------------
+-- 1. Enum type
+-- -----------------------------------------------------------------------------
+do $$
+begin
+  if not exists (
+    select 1 from pg_type where typname = 'cost_bearer_type'
+  ) then
+    create type public.cost_bearer_type as enum (
+      'health_insurance',
+      'self_payer',
+      'municipality',
+      'other'
+    );
+  end if;
+end$$;
+
+-- -----------------------------------------------------------------------------
+-- 2. Column on patients
+-- -----------------------------------------------------------------------------
+-- Nullable, NO default: existing rows stay NULL so the M8 billing logic is not
+-- affected (there is no cost-bearer-driven pricing today).
+alter table public.patients
+  add column if not exists cost_bearer public.cost_bearer_type;
+
+comment on column public.patients.cost_bearer is
+  'Kostenträger for this patient (health_insurance | self_payer | municipality | other). '
+  'PII/sensitive — staff-scoped via the existing patients RLS policies. Row-level RLS '
+  'covers this column; no column-level policy exists, so drivers who can read a patient '
+  'row (assigned active ride) technically see it — application code must NOT expose it to '
+  'driver views or the driver order-sheet copy.';
+
+-- -----------------------------------------------------------------------------
+-- 3. RLS
+-- -----------------------------------------------------------------------------
+-- No new policy required. RLS on public.patients is row-level and already:
+--   * patients_select_staff  — admin/operator full read (covers this column)
+--   * patients_insert_staff  — only admin/operator may insert
+--   * patients_update_staff  — only admin/operator may update
+-- These column-agnostic policies already scope the new column to staff for writes.

--- a/supabase/migrations/20260716_000001_ride_requirements.sql
+++ b/supabase/migrations/20260716_000001_ride_requirements.sql
@@ -1,0 +1,51 @@
+-- M13: Fahrt-Erfassung -- Ride requirements on ride level (Issue #126)
+--
+-- Goal: capture the transport requirements of a single ride (wheelchair,
+-- rollator, companion, oxygen, carry chair, stretcher) as an input for the
+-- later vehicle selection. This is a pure schema/helper change; the capture UI
+-- follows in #135.
+--
+-- Decisions (Issue #126):
+--   * NEW `ride_requirement` enum -- deliberately NOT reusing `impairment_type`
+--     (patient level, no oxygen). The new enum is a superset of impairment_type
+--     plus `oxygen` and `carry_chair`.
+--   * NO `vehicle_type` enum extension in M13. `vehicle_type` stays lean;
+--     `oxygen`/`carry_chair` remain purely informative requirement flags that do
+--     NOT introduce new vehicle types. Mapping lives in
+--     `src/lib/rides/requirements.ts` (requirementsToVehicleType).
+--   * `rides.has_escort` (tariff-relevant boolean) stays as-is. The `companion`
+--     requirement mirrors the same real-world fact; the two are intentionally
+--     NOT force-synced here to avoid double-bookkeeping. Any mirroring is an
+--     application-level concern to be decided in the capture UI (#135).
+
+-- =============================================================
+-- 1: Enum type
+-- =============================================================
+
+-- Superset of `impairment_type` (rollator/wheelchair/stretcher/companion)
+-- extended with `oxygen` and `carry_chair`.
+CREATE TYPE public.ride_requirement AS ENUM (
+  'wheelchair',
+  'rollator',
+  'companion',
+  'oxygen',
+  'carry_chair',
+  'stretcher'
+);
+
+-- =============================================================
+-- 2: Column
+-- =============================================================
+
+-- Set-valued requirements per ride. NOT NULL with an empty-array default so
+-- existing rows and inserts without requirements are well-defined (no NULLs).
+ALTER TABLE public.rides
+  ADD COLUMN IF NOT EXISTS requirements public.ride_requirement[] NOT NULL DEFAULT '{}';
+
+COMMENT ON COLUMN public.rides.requirements IS
+  'Transport requirements for this ride (Issue #126). Input for vehicle '
+  'selection via requirementsToVehicleType(). oxygen/carry_chair are '
+  'informative flags and do NOT map to a vehicle_type.';
+
+-- No RLS changes required: `requirements` is an additional column on the
+-- existing `rides` table and is covered by the table's existing policies.

--- a/supabase/migrations/20260717_000001_org_settings_time_buffers.sql
+++ b/supabase/migrations/20260717_000001_org_settings_time_buffers.sql
@@ -1,0 +1,36 @@
+-- =============================================================================
+-- Migration: Organization Settings — Zeit-Puffer-Defaults (Issue #128)
+-- =============================================================================
+-- Macht die bisher hartkodierten Zeit-Puffer als Org-Standard konfigurierbar.
+-- Ersetzt die Konstanten DEFAULT_PICKUP_BUFFER_MINUTES (5) und
+-- DEFAULT_RETURN_BUFFER_MINUTES (15) aus src/lib/validations/rides.ts.
+--
+-- Defaults = heutige Konstantenwerte => kein Verhaltensbruch.
+-- Puffer werden NICHT pro Fahrt persistiert (Design-Entscheidung #6, "simple
+-- first"): sie liefern nur die vorgeschlagene, ueberschreibbare Abholzeit.
+-- =============================================================================
+
+-- Vorlauf-Puffer (Minuten), der vor der Fahrtdauer abgezogen wird, damit der
+-- Fahrer rechtzeitig beim Patienten ist. Default 5 = DEFAULT_PICKUP_BUFFER_MINUTES.
+ALTER TABLE organization_settings
+    ADD COLUMN IF NOT EXISTS default_pickup_buffer_minutes INT NOT NULL DEFAULT 5;
+
+-- Ein-/Aussteige-Zeit (Minuten) fuer das Boarding beim Patienten.
+-- Default 0 (heute nicht separat modelliert).
+ALTER TABLE organization_settings
+    ADD COLUMN IF NOT EXISTS default_boarding_minutes INT NOT NULL DEFAULT 0;
+
+-- Rueckfahr-Puffer (Minuten) zwischen appointment_end_time und
+-- return_pickup_time. Default 15 = DEFAULT_RETURN_BUFFER_MINUTES.
+ALTER TABLE organization_settings
+    ADD COLUMN IF NOT EXISTS default_return_buffer_minutes INT NOT NULL DEFAULT 15;
+
+-- Wertebereich absichern (0-120 Minuten), passend zur Zod-Validierung.
+ALTER TABLE organization_settings
+    DROP CONSTRAINT IF EXISTS organization_settings_buffer_range;
+ALTER TABLE organization_settings
+    ADD CONSTRAINT organization_settings_buffer_range CHECK (
+        default_pickup_buffer_minutes BETWEEN 0 AND 120
+        AND default_boarding_minutes BETWEEN 0 AND 120
+        AND default_return_buffer_minutes BETWEEN 0 AND 120
+    );


### PR DESCRIPTION
Milestone **M13** – die ganze Fahrt-Erfassung auf einer Seite (`/rides/erfassen`).

## Umgesetzt (Issues #125–#140)
- **DB-Fundament:** `patients.cost_bearer`, `ride_requirement`-Set + `rides.requirements`, Org-Zeit-Puffer (Migrationen 20260715–717, **bereits auf Prod-DB angewandt**).
- **Logik:** Abholzeit-Berechnung mit Org-Puffer/Boarding (#129); Server Actions persistieren `requirements` + „nie-blockieren"-Warnungen (#130).
- **Seite:** Zwei-Spalten-`RideCaptureForm` mit Slot-Architektur (#131) + Fan-out Karte/Preis/Inline-Anlage/Bedarfs-Chips/Serien-Toggle/Kostenträger (#132–#137).
- **Abschluss:** Speichern-Fluss + Auftragsblatt-Anschluss M11 (#139); Tests/ADR-014/Guide (#140).

## Verifikation
tsc · lint · build · **840 Tests** grün.

## ⚠️ Reconciliation mit M14 nötig
Basiert auf origin/main VOR dem M14-Merge (#161). Erwartete additive Konflikte auf gemeinsamen Dateien:
- `src/lib/types/database.ts` (`organization_settings`: M13-Puffer + M14-Finanzspalten → beide behalten)
- `src/actions/rides.ts` (M14 `isPriceCalculationFailure`-Guard + M13 `save_intent`/`priceResolved` → kombinieren)
- `src/lib/validations/patients.ts` / `patient-form.tsx` (M13 `cost_bearer` + M14-Änderungen)
- Migrationen: M13 20260715–717 vor M14 20260718 → keine Datum-Kollision

3× Ioannis-Security (freigegeben; CB-01 `patients_driver_view` als Follow-up offen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)