### PR TITLE
feat(m15): assignment_events — Status-Historie pro Fahrt (#164)

### DIFF
--- a/src/actions/acceptance.ts
+++ b/src/actions/acceptance.ts
@@ -9,6 +9,7 @@ import {
   cancelAcceptanceTracking,
 } from "@/lib/acceptance/engine"
 import { isAcceptanceFlowEnabled } from "@/lib/acceptance/constants"
+import { recordAssignmentEvent } from "@/lib/acceptance/events"
 import { rejectionSchema } from "@/lib/validations/acceptance"
 import { uuidSchema } from "@/lib/validations/shared"
 import { logAudit } from "@/lib/audit/logger"
@@ -66,6 +67,15 @@ export async function confirmAssignment(
 
   // Resolve acceptance tracking
   await resolveAcceptance(rideId, "confirmed", "driver_app")
+
+  // Append to the per-ride status history (assignment_events, Issue #164):
+  // driver confirmed. actor is derived server-side from the session (#185).
+  await recordAssignmentEvent({
+    rideId,
+    driverId: auth.driverId,
+    event: "confirmed",
+    actor: "driver",
+  })
 
   revalidatePath("/my/rides")
   revalidatePath("/dispatch")
@@ -147,6 +157,17 @@ export async function rejectAssignment(
     result.data.rejection_text ?? undefined
   )
 
+  // Append to the per-ride status history (assignment_events, Issue #164):
+  // driver rejected. The reason code is kept as human-readable detail; actor is
+  // derived server-side from the session (#185).
+  await recordAssignmentEvent({
+    rideId,
+    driverId: auth.driverId,
+    event: "rejected",
+    actor: "driver",
+    detail: result.data.rejection_reason,
+  })
+
   revalidatePath("/my/rides")
   revalidatePath("/dispatch")
   revalidatePath("/rides")
@@ -213,6 +234,16 @@ export async function reassignRide(
       status: { old: ride.status, new: "unplanned" },
     },
   }).catch(() => {})
+
+  // Append to the per-ride status history (assignment_events, Issue #164):
+  // dispatcher reassigned the ride (driver removed, back to the pool). actor is
+  // derived server-side (#185).
+  await recordAssignmentEvent({
+    rideId: parsedId.data,
+    driverId: ride.driver_id,
+    event: "reassigned",
+    actor: "dispatcher",
+  })
 
   revalidatePath("/dispatch")
   revalidatePath("/rides")

--- a/src/actions/rides.ts
+++ b/src/actions/rides.ts
@@ -18,6 +18,7 @@ import {
   createAcceptanceTracking,
   cancelAcceptanceTracking,
 } from "@/lib/acceptance/engine"
+import { recordAssignmentEvent } from "@/lib/acceptance/events"
 import {
   generateDatesForSeries,
   expandDirections,
@@ -1225,6 +1226,26 @@ export async function assignDriver(
     return { success: false, error: error.message }
   }
 
+  const driverChanged = driverId !== currentRide.driver_id
+  const newStatus = updateData.status ?? currentRide.status
+
+  // Manipulation-safe audit trail for every assignment/removal (finding #181):
+  // assignDriver previously wrote no audit_log entry. "assign" when a driver is
+  // set, "reassign" when a driver is removed or replaced.
+  if (driverChanged) {
+    logAudit({
+      userId: auth.userId,
+      userRole: auth.role,
+      action: driverId ? "assign" : "reassign",
+      entityType: "ride",
+      entityId: rideId,
+      changes: {
+        driver_id: { old: currentRide.driver_id, new: driverId },
+        status: { old: currentRide.status, new: newStatus },
+      },
+    }).catch(() => {})
+  }
+
   // Note out-of-availability assignment in the communication_log (Issue #104)
   if (driverId && driverStatus && !driverStatus.isWithinAvailability) {
     await logOutsideAvailabilityAssignment(supabase, {
@@ -1241,6 +1262,15 @@ export async function assignDriver(
 
     // Fire-and-forget: send driver notification email
     sendDriverNotification(rideId, driverId).catch(console.error)
+
+    // Append to the per-ride status history (assignment_events, Issue #164):
+    // dispatcher requested this driver. actor is derived server-side (#185).
+    await recordAssignmentEvent({
+      rideId,
+      driverId,
+      event: "requested",
+      actor: "dispatcher",
+    })
 
     // Create acceptance tracking if feature is enabled
     if (isAcceptanceFlowEnabled()) {
@@ -1268,6 +1298,15 @@ export async function assignDriver(
     if (isAcceptanceFlowEnabled()) {
       await cancelAcceptanceTracking(rideId)
     }
+
+    // Append to the per-ride status history (assignment_events, Issue #164):
+    // dispatcher removed the driver, ride returns to the pool for reassignment.
+    await recordAssignmentEvent({
+      rideId,
+      driverId: currentRide.driver_id,
+      event: "reassigned",
+      actor: "dispatcher",
+    })
   }
 
   revalidatePath("/dispatch")

--- a/src/app/api/rides/respond/route.ts
+++ b/src/app/api/rides/respond/route.ts
@@ -4,6 +4,7 @@ import { consumeToken, invalidateTokensForRide } from "@/lib/mail/tokens"
 import { canTransition } from "@/lib/rides/status-machine"
 import { isAcceptanceFlowEnabled } from "@/lib/acceptance/constants"
 import { resolveAcceptance } from "@/lib/acceptance/engine"
+import { recordAssignmentEvent } from "@/lib/acceptance/events"
 import { rateLimitRideRespond } from "@/lib/security/rate-limit"
 import type { Enums } from "@/lib/types/database"
 
@@ -157,6 +158,17 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  // 9. Redirect to success page
+  // 9. Append to the per-ride status history (assignment_events, Issue #164):
+  // driver responded from the email 1-click link. The driver_id comes from the
+  // consumed token (server-verified above against the ride), never from client
+  // input; actor is the driver (#185).
+  await recordAssignmentEvent({
+    rideId: tokenData.ride_id,
+    driverId: tokenData.driver_id,
+    event: validAction === "confirm" ? "confirmed" : "rejected",
+    actor: "driver",
+  })
+
+  // 10. Redirect to success page
   return successRedirect(request, validAction)
 }

--- a/src/lib/acceptance/__tests__/events.test.ts
+++ b/src/lib/acceptance/__tests__/events.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockInsert = vi.fn()
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: vi.fn().mockReturnValue({
+      insert: mockInsert,
+    }),
+  })),
+}))
+
+// Import after mock
+import { recordAssignmentEvent } from "../events"
+
+describe("recordAssignmentEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("inserts a fully-specified assignment event", async () => {
+    mockInsert.mockResolvedValue({ error: null })
+
+    await recordAssignmentEvent({
+      rideId: "ride-1",
+      driverId: "driver-1",
+      acceptanceTrackingId: "track-1",
+      event: "reminder_sent",
+      actor: "system",
+      detail: "reminder_2",
+    })
+
+    expect(mockInsert).toHaveBeenCalledOnce()
+    expect(mockInsert).toHaveBeenCalledWith({
+      ride_id: "ride-1",
+      driver_id: "driver-1",
+      acceptance_tracking_id: "track-1",
+      event: "reminder_sent",
+      actor: "system",
+      detail: "reminder_2",
+    })
+  })
+
+  it("defaults optional fields to null", async () => {
+    mockInsert.mockResolvedValue({ error: null })
+
+    await recordAssignmentEvent({
+      rideId: "ride-2",
+      event: "requested",
+      actor: "dispatcher",
+    })
+
+    expect(mockInsert).toHaveBeenCalledWith({
+      ride_id: "ride-2",
+      driver_id: null,
+      acceptance_tracking_id: null,
+      event: "requested",
+      actor: "dispatcher",
+      detail: null,
+    })
+  })
+
+  it("persists the server-derived actor verbatim (no client override)", async () => {
+    mockInsert.mockResolvedValue({ error: null })
+
+    await recordAssignmentEvent({
+      rideId: "ride-3",
+      driverId: "driver-3",
+      event: "confirmed",
+      actor: "driver",
+    })
+
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ actor: "driver", event: "confirmed" })
+    )
+  })
+
+  // ---- Never throws ----
+
+  it("does not throw when Supabase insert returns an error", async () => {
+    mockInsert.mockResolvedValue({
+      error: { message: "insert failed", code: "42P01" },
+    })
+
+    await expect(
+      recordAssignmentEvent({
+        rideId: "ride-4",
+        event: "cancelled",
+        actor: "dispatcher",
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  it("does not throw when Supabase insert rejects", async () => {
+    mockInsert.mockRejectedValue(new Error("network error"))
+
+    await expect(
+      recordAssignmentEvent({
+        rideId: "ride-5",
+        event: "timed_out",
+        actor: "system",
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  it("does not throw when createAdminClient throws", async () => {
+    const { createAdminClient } = await import("@/lib/supabase/admin")
+    vi.mocked(createAdminClient).mockImplementationOnce(() => {
+      throw new Error("missing env var")
+    })
+
+    await expect(
+      recordAssignmentEvent({
+        rideId: "ride-6",
+        event: "reassigned",
+        actor: "dispatcher",
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  // ---- Console error logging ----
+
+  it("logs to console.error when insert returns an error", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    mockInsert.mockResolvedValue({ error: { message: "permission denied" } })
+
+    await recordAssignmentEvent({
+      rideId: "ride-7",
+      event: "requested",
+      actor: "dispatcher",
+    })
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[assignment-events] Failed to insert event:",
+      "permission denied"
+    )
+    consoleSpy.mockRestore()
+  })
+})

--- a/src/lib/acceptance/engine.ts
+++ b/src/lib/acceptance/engine.ts
@@ -1,4 +1,5 @@
 import { createAdminClient } from "@/lib/supabase/admin"
+import { recordAssignmentEvent } from "./events"
 import {
   NORMAL_SLA_WINDOWS,
   SHORT_NOTICE_SLA_WINDOWS,
@@ -226,6 +227,31 @@ export async function checkPendingAcceptances(): Promise<EscalationResult[]> {
         toStage: nextStage,
         escalated,
       })
+
+      // Append to the per-ride status history (assignment_events, Issue #164):
+      // the system escalated this request. Only record when the atomic stage
+      // transition actually happened (SEC-M9-004). The reminder stage / timeout
+      // is kept as human-readable detail; actor is the system.
+      if (escalated) {
+        if (nextStage === "reminder_1" || nextStage === "reminder_2") {
+          await recordAssignmentEvent({
+            rideId: tracking.ride_id,
+            driverId: tracking.driver_id,
+            acceptanceTrackingId: tracking.id,
+            event: "reminder_sent",
+            actor: "system",
+            detail: nextStage,
+          })
+        } else if (nextStage === "timed_out") {
+          await recordAssignmentEvent({
+            rideId: tracking.ride_id,
+            driverId: tracking.driver_id,
+            acceptanceTrackingId: tracking.id,
+            event: "timed_out",
+            actor: "system",
+          })
+        }
+      }
 
       // Send reminder emails for reminder stages
       if (escalated && (nextStage === "reminder_1" || nextStage === "reminder_2")) {

--- a/src/lib/acceptance/events.ts
+++ b/src/lib/acceptance/events.ts
@@ -1,0 +1,58 @@
+import { createAdminClient } from "@/lib/supabase/admin"
+import type { Enums } from "@/lib/types/database"
+
+export type AssignmentEventType = Enums<"assignment_event_type">
+export type AssignmentActor = Enums<"assignment_actor">
+
+interface RecordAssignmentEventInput {
+  rideId: string
+  /** The event that occurred (see assignment_event_type enum). */
+  event: AssignmentEventType
+  /**
+   * Who triggered the event. MUST be set server-side (dispatcher/driver/system)
+   * from the authenticated session or system context — never from client input
+   * (security finding #185).
+   */
+  actor: AssignmentActor
+  driverId?: string | null
+  acceptanceTrackingId?: string | null
+  /** Optional free-text detail, e.g. rejection reason or reminder stage. */
+  detail?: string | null
+}
+
+/**
+ * Append an entry to the per-ride assignment status history (assignment_events).
+ *
+ * Writes go exclusively through the admin (service-role) client — the table has
+ * no user-facing INSERT policy and is append-only (#185). This function is
+ * intentionally fire-and-forget safe: it catches all errors internally so that
+ * recording history never breaks the underlying assignment operation.
+ *
+ * The rights-binding audit proof lives in the immutable `audit_log` (#181); this
+ * table is the dispatcher-facing operational timeline.
+ */
+export async function recordAssignmentEvent(
+  input: RecordAssignmentEventInput
+): Promise<void> {
+  try {
+    const supabase = createAdminClient()
+    const { error } = await supabase.from("assignment_events").insert({
+      ride_id: input.rideId,
+      driver_id: input.driverId ?? null,
+      acceptance_tracking_id: input.acceptanceTrackingId ?? null,
+      event: input.event,
+      actor: input.actor,
+      detail: input.detail ?? null,
+    })
+
+    if (error) {
+      console.error(
+        "[assignment-events] Failed to insert event:",
+        error.message
+      )
+    }
+  } catch (error) {
+    // Recording history must never break the main assignment operation.
+    console.error("[assignment-events] Failed to record event:", error)
+  }
+}

--- a/src/lib/audit/logger.ts
+++ b/src/lib/audit/logger.ts
@@ -6,6 +6,7 @@ type AuditAction =
   | "update"
   | "delete"
   | "status_change"
+  | "assign"
   | "reassign"
   | "login"
   | "deactivate"

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -86,6 +86,61 @@ export type Database = {
           },
         ]
       }
+      assignment_events: {
+        Row: {
+          acceptance_tracking_id: string | null
+          actor: Database["public"]["Enums"]["assignment_actor"]
+          created_at: string
+          detail: string | null
+          driver_id: string | null
+          event: Database["public"]["Enums"]["assignment_event_type"]
+          id: string
+          ride_id: string
+        }
+        Insert: {
+          acceptance_tracking_id?: string | null
+          actor: Database["public"]["Enums"]["assignment_actor"]
+          created_at?: string
+          detail?: string | null
+          driver_id?: string | null
+          event: Database["public"]["Enums"]["assignment_event_type"]
+          id?: string
+          ride_id: string
+        }
+        Update: {
+          acceptance_tracking_id?: string | null
+          actor?: Database["public"]["Enums"]["assignment_actor"]
+          created_at?: string
+          detail?: string | null
+          driver_id?: string | null
+          event?: Database["public"]["Enums"]["assignment_event_type"]
+          id?: string
+          ride_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "assignment_events_acceptance_tracking_id_fkey"
+            columns: ["acceptance_tracking_id"]
+            isOneToOne: false
+            referencedRelation: "acceptance_tracking"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assignment_events_driver_id_fkey"
+            columns: ["driver_id"]
+            isOneToOne: false
+            referencedRelation: "drivers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assignment_events_ride_id_fkey"
+            columns: ["ride_id"]
+            isOneToOne: false
+            referencedRelation: "rides"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       assignment_tokens: {
         Row: {
           action: string | null
@@ -1371,6 +1426,15 @@ export type Database = {
         | "confirmed"
         | "rejected"
         | "cancelled"
+      assignment_actor: "dispatcher" | "driver" | "system"
+      assignment_event_type:
+        | "requested"
+        | "reminder_sent"
+        | "confirmed"
+        | "rejected"
+        | "timed_out"
+        | "reassigned"
+        | "cancelled"
       cost_bearer_type:
         | "health_insurance"
         | "self_payer"
@@ -1561,6 +1625,16 @@ export const Constants = {
         "timed_out",
         "confirmed",
         "rejected",
+        "cancelled",
+      ],
+      assignment_actor: ["dispatcher", "driver", "system"],
+      assignment_event_type: [
+        "requested",
+        "reminder_sent",
+        "confirmed",
+        "rejected",
+        "timed_out",
+        "reassigned",
         "cancelled",
       ],
       cost_bearer_type: [

--- a/supabase/migrations/20260724_000001_assignment_events.sql
+++ b/supabase/migrations/20260724_000001_assignment_events.sql
@@ -1,0 +1,71 @@
+-- Assignment Events: append-only status history per ride (M15, Issue #164)
+-- Structured, per-ride event log spanning multiple acceptance_tracking attempts.
+-- Security findings honored:
+--   #176 (CRITICAL): RLS mandatory. Staff read all, drivers read only their own.
+--   #185 (MEDIUM):   append-only. Writes exclusively via service-role client.
+--                    No user INSERT/UPDATE/DELETE policies. actor set server-side.
+--   #181 (HIGH):     legally-binding proof still lives in the immutable audit_log;
+--                    this table is the dispatcher-facing operational history.
+
+-- 1. Create enums
+CREATE TYPE assignment_event_type AS ENUM (
+  'requested',
+  'reminder_sent',
+  'confirmed',
+  'rejected',
+  'timed_out',
+  'reassigned',
+  'cancelled'
+);
+
+CREATE TYPE assignment_actor AS ENUM (
+  'dispatcher',
+  'driver',
+  'system'
+);
+
+-- 2. Create assignment_events table (append-only, no updated_at)
+CREATE TABLE assignment_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  ride_id uuid NOT NULL REFERENCES rides(id) ON DELETE CASCADE,
+  driver_id uuid REFERENCES drivers(id) ON DELETE SET NULL,
+  acceptance_tracking_id uuid REFERENCES acceptance_tracking(id) ON DELETE SET NULL,
+  event assignment_event_type NOT NULL,
+  actor assignment_actor NOT NULL,
+  detail text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT assignment_events_detail_length CHECK (
+    detail IS NULL OR char_length(detail) <= 500
+  )
+);
+
+-- 3. Index for the per-ride timeline query (ordered chronologically)
+CREATE INDEX idx_assignment_events_ride_created
+  ON assignment_events (ride_id, created_at);
+
+-- 4. Index for driver lookups (RLS-scoped driver timeline)
+CREATE INDEX idx_assignment_events_driver
+  ON assignment_events (driver_id);
+
+-- 5. Enable RLS
+ALTER TABLE assignment_events ENABLE ROW LEVEL SECURITY;
+
+-- Staff (admin/operator) can read all events
+CREATE POLICY "Staff can view assignment events"
+  ON assignment_events FOR SELECT
+  USING (
+    (SELECT get_user_role()) IN ('admin', 'operator')
+  );
+
+-- Drivers can read only their own events
+CREATE POLICY "Drivers can view own assignment events"
+  ON assignment_events FOR SELECT
+  USING (
+    (SELECT get_user_role()) = 'driver'
+    AND driver_id = (SELECT get_user_driver_id())
+  );
+
+-- No INSERT/UPDATE/DELETE policies: append-only, writes exclusively via the
+-- service-role (admin) client in Server Actions. actor/actor_id are derived
+-- server-side from the authenticated session, never from client input (#185).


### PR DESCRIPTION
Closes #164

Teil von **M15 – Fahrer-Zuweisung & Workflow**, Phase 15.1 (Fundament).

## Was

Append-only Ereignisprotokoll `assignment_events` als strukturierte Status-Historie pro Fahrt über mehrere Anfrage-Versuche hinweg (Konzept §3.1). **Keine** neue `assignments`-Tabelle — `acceptance_tracking` bleibt die Anfrage-Entität (EPIC #175).

## Migration `20260724_000001_assignment_events.sql`
- Enum `assignment_event_type` (`requested`, `reminder_sent`, `confirmed`, `rejected`, `timed_out`, `reassigned`, `cancelled`)
- Enum `assignment_actor` (`dispatcher`, `driver`, `system`)
- Tabelle `assignment_events`: `id`, `ride_id` (FK → rides ON DELETE CASCADE), `driver_id` (FK, nullable), `acceptance_tracking_id` (FK, nullable), `event`, `actor`, `detail`, `created_at`
- Index `(ride_id, created_at)` für die Timeline-Abfrage + Index auf `driver_id`
- RLS aktiviert

## Security-Findings
- **#176 (CRITICAL):** RLS Pflicht. Staff (`admin`/`operator`) SELECT alle via `get_user_role()`, Fahrer nur eigene Zeilen via `get_user_driver_id()`. Keine INSERT/UPDATE/DELETE-Policies für Nutzer.
- **#185 (MEDIUM):** append-only, nur Service-Role beschreibbar. `actor` wird serverseitig aus Session/Systemkontext gesetzt, nie aus Client-Input. Keine UPDATE/DELETE-Policies.
- **#181 (HIGH):** `assignDriver()` schreibt jetzt in den immutablen `audit_log` via `logAudit(action: "assign"/"reassign")` mit Akteur (userId, role) und `driver_id`/`status`-Diff (bisher komplett ungeloggt).

## Event-Writer
`recordAssignmentEvent()` in `src/lib/acceptance/events.ts` — nutzt `createAdminClient()`, fire-and-forget-safe (bricht die Zuweisung nie ab).

## Verdrahtung
| Auslöser | Event | Actor |
|---|---|---|
| `assignDriver` (Fahrer gesetzt) | `requested` | dispatcher |
| `assignDriver` (Fahrer entfernt) | `reassigned` | dispatcher |
| `engine.ts` Eskalation (reminder_1/2) | `reminder_sent` | system |
| `engine.ts` Eskalation (timeout) | `timed_out` | system |
| `confirmAssignment` / respond POST confirm | `confirmed` | driver |
| `rejectAssignment` / respond POST reject | `rejected` | driver |
| `reassignRide` | `reassigned` | dispatcher |

## Sonstiges
- DB-Typen (`src/lib/types/database.ts`) für neue Tabelle + Enums ergänzt.
- Unit-Test für `recordAssignmentEvent` (7 Cases).

## Verifikation
- `npx tsc --noEmit`: grün
- `next lint` (geänderte Dateien): keine Warnings/Errors
- `vitest run`: 1025 Tests grün (67 Files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)