### PR TITLE
feat(m15): SLA-Fenster auf 24h/48h (kurzfristig 4h/8h) (#165)

### DIFF
--- a/src/app/api/cron/acceptance-check/route.ts
+++ b/src/app/api/cron/acceptance-check/route.ts
@@ -4,9 +4,17 @@ import { checkPendingAcceptances } from "@/lib/acceptance/engine"
 
 /**
  * Vercel Cron endpoint for acceptance tracking escalation.
- * Runs hourly (see vercel.json) to check for overdue driver responses and
- * drive the 24h/48h — resp. 4h/8h short-notice — reminder/escalation windows.
- * The fire-and-forget call on the dispatch page is a supplementary safety net.
+ * Runs once daily at 06:00 (see vercel.json) to check for overdue driver
+ * responses and drive the reminder/escalation windows.
+ *
+ * Cadence note: the Vercel Hobby plan only permits daily crons (a deliberate
+ * decision — no plan upgrade, no external scheduler). Consequences:
+ * - The 24h/48h normal windows are only hit at day granularity (a record
+ *   crossing its deadline is escalated at the next 06:00 run).
+ * - The 4h/8h short-notice windows cannot be met by this daily cron; that
+ *   escalation is primarily carried by the fire-and-forget
+ *   `checkPendingAcceptances()` call when the dispatch page is loaded, which
+ *   catches due deadlines throughout the working day.
  *
  * Auth: CRON_SECRET in Authorization header (Vercel sets this automatically).
  * The response body only contains opaque IDs (ride/driver/tracking UUIDs) — no

--- a/src/app/api/cron/acceptance-check/route.ts
+++ b/src/app/api/cron/acceptance-check/route.ts
@@ -4,9 +4,13 @@ import { checkPendingAcceptances } from "@/lib/acceptance/engine"
 
 /**
  * Vercel Cron endpoint for acceptance tracking escalation.
- * Runs every minute to check for overdue driver responses.
+ * Runs hourly (see vercel.json) to check for overdue driver responses and
+ * drive the 24h/48h — resp. 4h/8h short-notice — reminder/escalation windows.
+ * The fire-and-forget call on the dispatch page is a supplementary safety net.
  *
  * Auth: CRON_SECRET in Authorization header (Vercel sets this automatically).
+ * The response body only contains opaque IDs (ride/driver/tracking UUIDs) — no
+ * patient PII is logged or returned (#186).
  */
 export async function GET(request: Request) {
   // Verify cron secret

--- a/src/lib/acceptance/__tests__/constants.test.ts
+++ b/src/lib/acceptance/__tests__/constants.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, afterEach } from "vitest"
 import {
+  MINUTES_PER_HOUR,
   NORMAL_SLA_WINDOWS,
   SHORT_NOTICE_SLA_WINDOWS,
   SHORT_NOTICE_THRESHOLD_MINUTES,
@@ -13,36 +14,32 @@ import {
 import type { AcceptanceStage, RejectionReason } from "../types"
 
 describe("SLA Windows", () => {
-  it("normal windows are in ascending order", () => {
-    expect(NORMAL_SLA_WINDOWS.reminder1).toBeLessThan(NORMAL_SLA_WINDOWS.reminder2)
-    expect(NORMAL_SLA_WINDOWS.reminder2).toBeLessThan(NORMAL_SLA_WINDOWS.timeout)
+  it("normal windows are in ascending order (reminder before timeout)", () => {
+    expect(NORMAL_SLA_WINDOWS.reminder1).toBeLessThan(NORMAL_SLA_WINDOWS.timeout)
   })
 
-  it("short-notice windows are in ascending order", () => {
-    expect(SHORT_NOTICE_SLA_WINDOWS.reminder1).toBeLessThan(SHORT_NOTICE_SLA_WINDOWS.reminder2)
-    expect(SHORT_NOTICE_SLA_WINDOWS.reminder2).toBeLessThan(SHORT_NOTICE_SLA_WINDOWS.timeout)
+  it("short-notice windows are in ascending order (reminder before timeout)", () => {
+    expect(SHORT_NOTICE_SLA_WINDOWS.reminder1).toBeLessThan(SHORT_NOTICE_SLA_WINDOWS.timeout)
   })
 
   it("short-notice windows are shorter than normal windows", () => {
     expect(SHORT_NOTICE_SLA_WINDOWS.reminder1).toBeLessThan(NORMAL_SLA_WINDOWS.reminder1)
-    expect(SHORT_NOTICE_SLA_WINDOWS.reminder2).toBeLessThan(NORMAL_SLA_WINDOWS.reminder2)
     expect(SHORT_NOTICE_SLA_WINDOWS.timeout).toBeLessThan(NORMAL_SLA_WINDOWS.timeout)
   })
 
-  it("short-notice threshold is 60 minutes", () => {
-    expect(SHORT_NOTICE_THRESHOLD_MINUTES).toBe(60)
+  it("short-notice threshold is 48h (concept §3.3)", () => {
+    expect(SHORT_NOTICE_THRESHOLD_MINUTES).toBe(48 * MINUTES_PER_HOUR)
+    expect(SHORT_NOTICE_THRESHOLD_MINUTES).toBe(2880)
   })
 
-  it("normal windows have expected values", () => {
-    expect(NORMAL_SLA_WINDOWS.reminder1).toBe(10)
-    expect(NORMAL_SLA_WINDOWS.reminder2).toBe(25)
-    expect(NORMAL_SLA_WINDOWS.timeout).toBe(40)
+  it("normal windows are 24h reminder / 48h timeout", () => {
+    expect(NORMAL_SLA_WINDOWS.reminder1).toBe(24 * MINUTES_PER_HOUR) // 1440
+    expect(NORMAL_SLA_WINDOWS.timeout).toBe(48 * MINUTES_PER_HOUR) // 2880
   })
 
-  it("short-notice windows have expected values", () => {
-    expect(SHORT_NOTICE_SLA_WINDOWS.reminder1).toBe(3)
-    expect(SHORT_NOTICE_SLA_WINDOWS.reminder2).toBe(8)
-    expect(SHORT_NOTICE_SLA_WINDOWS.timeout).toBe(15)
+  it("short-notice windows are 4h reminder / 8h timeout", () => {
+    expect(SHORT_NOTICE_SLA_WINDOWS.reminder1).toBe(4 * MINUTES_PER_HOUR) // 240
+    expect(SHORT_NOTICE_SLA_WINDOWS.timeout).toBe(8 * MINUTES_PER_HOUR) // 480
   })
 })
 

--- a/src/lib/acceptance/__tests__/engine.test.ts
+++ b/src/lib/acceptance/__tests__/engine.test.ts
@@ -170,7 +170,7 @@ describe("escalation flow / idempotency semantics", () => {
   })
 
   it("does not re-fire the reminder once the record advanced past 'notified'", () => {
-    // A second hourly cron run at 25h sees the record already at reminder_1.
+    // A second check run at 25h sees the record already at reminder_1.
     // The reminder deadline no longer applies; only the 48h timeout can fire.
     const now = notifiedMs + 25 * MS_PER_HOUR
     expect(isDue("reminder_1", false, now)).toBe(false)

--- a/src/lib/acceptance/__tests__/engine.test.ts
+++ b/src/lib/acceptance/__tests__/engine.test.ts
@@ -1,105 +1,184 @@
-import { describe, expect, it, vi, beforeEach } from "vitest"
-import { isShortNotice, getSLAWindows } from "../engine"
+import { describe, expect, it, vi, afterEach, beforeEach } from "vitest"
+import { isShortNotice, getSLAWindows, nextDeadline } from "../engine"
 import {
+  MINUTES_PER_HOUR,
   NORMAL_SLA_WINDOWS,
   SHORT_NOTICE_SLA_WINDOWS,
   SHORT_NOTICE_THRESHOLD_MINUTES,
 } from "../constants"
+import { zurichWallTimeToUtc } from "@/lib/utils/dates"
 
-describe("isShortNotice", () => {
+const MS_PER_HOUR = 60 * 60 * 1000
+
+describe("isShortNotice (48h threshold, timezone-safe)", () => {
   beforeEach(() => {
     vi.useFakeTimers()
   })
-
-  it("returns true when pickup is less than 60 minutes away", () => {
-    // Set "now" to 30 min before pickup (local time)
-    const pickup = new Date("2026-03-05T10:30:00")
-    vi.setSystemTime(new Date(pickup.getTime() - 30 * 60 * 1000))
-
-    expect(isShortNotice("2026-03-05", "10:30:00")).toBe(true)
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
-  it("returns false when pickup is more than 60 minutes away", () => {
-    // Set "now" to 2 hours before pickup
-    const pickup = new Date("2026-03-05T10:00:00")
-    vi.setSystemTime(new Date(pickup.getTime() - 120 * 60 * 1000))
+  // Reference ride: 2026-03-05 (winter → CET, UTC+1). The helper resolves the
+  // Zurich wall time to an absolute instant so the machine's own TZ is irrelevant.
+  const RIDE_DATE = "2026-03-05"
+  const RIDE_TIME = "10:00:00"
+  const pickupMs = zurichWallTimeToUtc(RIDE_DATE, RIDE_TIME).getTime()
 
-    expect(isShortNotice("2026-03-05", "10:00:00")).toBe(false)
+  it("is true when the ride starts less than 48h away", () => {
+    vi.setSystemTime(new Date(pickupMs - 47 * MS_PER_HOUR))
+    expect(isShortNotice(RIDE_DATE, RIDE_TIME)).toBe(true)
   })
 
-  it("returns false when pickup is exactly at the threshold (60 min away)", () => {
-    // Use a time that ensures exactly 60 minutes difference
-    // isShortNotice uses `new Date(date + 'T' + time)` which is local time
-    const pickup = new Date("2026-03-05T10:00:00")
-    const now = new Date(pickup.getTime() - SHORT_NOTICE_THRESHOLD_MINUTES * 60 * 1000)
-    vi.setSystemTime(now)
-
-    // Exactly 60 minutes away → diffMinutes = 60 → NOT < 60 → false
-    expect(isShortNotice("2026-03-05", "10:00:00")).toBe(false)
+  it("is false when the ride starts more than 48h away", () => {
+    vi.setSystemTime(new Date(pickupMs - 49 * MS_PER_HOUR))
+    expect(isShortNotice(RIDE_DATE, RIDE_TIME)).toBe(false)
   })
 
-  it("returns true when pickup is 59 minutes away", () => {
-    const pickup = new Date("2026-03-05T10:00:00")
-    vi.setSystemTime(new Date(pickup.getTime() - 59 * 60 * 1000))
-
-    expect(isShortNotice("2026-03-05", "10:00:00")).toBe(true)
+  it("is false exactly at the 48h threshold (not strictly less)", () => {
+    vi.setSystemTime(new Date(pickupMs - SHORT_NOTICE_THRESHOLD_MINUTES * 60 * 1000))
+    expect(isShortNotice(RIDE_DATE, RIDE_TIME)).toBe(false)
   })
 
-  it("returns true when pickup is in the past", () => {
-    const pickup = new Date("2026-03-05T10:00:00")
-    vi.setSystemTime(new Date(pickup.getTime() + 120 * 60 * 1000))
+  it("is true when the ride start is in the past", () => {
+    vi.setSystemTime(new Date(pickupMs + 2 * MS_PER_HOUR))
+    expect(isShortNotice(RIDE_DATE, RIDE_TIME)).toBe(true)
+  })
+})
 
-    expect(isShortNotice("2026-03-05", "10:00:00")).toBe(true)
+describe("zurichWallTimeToUtc (DST handling)", () => {
+  it("resolves a winter (CET, UTC+1) wall time correctly", () => {
+    // 2026-03-05 10:00 Zurich == 09:00 UTC
+    expect(zurichWallTimeToUtc("2026-03-05", "10:00:00").toISOString()).toBe(
+      "2026-03-05T09:00:00.000Z"
+    )
   })
 
-  it("returns false for a next-day pickup", () => {
-    const pickup = new Date("2026-03-05T10:00:00")
-    vi.setSystemTime(pickup)
-
-    // Tomorrow's pickup is 24 hours away
-    expect(isShortNotice("2026-03-06", "10:00:00")).toBe(false)
+  it("resolves a summer (CEST, UTC+2) wall time correctly", () => {
+    // 2026-07-15 10:00 Zurich == 08:00 UTC
+    expect(zurichWallTimeToUtc("2026-07-15", "10:00:00").toISOString()).toBe(
+      "2026-07-15T08:00:00.000Z"
+    )
   })
 })
 
 describe("getSLAWindows", () => {
   it("returns normal windows when not short notice", () => {
-    const windows = getSLAWindows(false)
-    expect(windows).toEqual(NORMAL_SLA_WINDOWS)
+    expect(getSLAWindows(false)).toEqual(NORMAL_SLA_WINDOWS)
   })
 
   it("returns short-notice windows when short notice", () => {
-    const windows = getSLAWindows(true)
-    expect(windows).toEqual(SHORT_NOTICE_SLA_WINDOWS)
+    expect(getSLAWindows(true)).toEqual(SHORT_NOTICE_SLA_WINDOWS)
   })
 })
 
-describe("escalation flow", () => {
-  it("normal flow stages: notified → reminder_1 → reminder_2 → timed_out", () => {
-    // This test documents the expected escalation chain
-    const stages = ["notified", "reminder_1", "reminder_2", "timed_out"] as const
-    const windows = NORMAL_SLA_WINDOWS
+describe("nextDeadline (single source for cron + UI)", () => {
+  const NOTIFIED = "2026-03-05T08:00:00.000Z"
+  const notifiedMs = new Date(NOTIFIED).getTime()
 
-    // Stage transitions happen at: 10min, 25min, 40min
-    expect(windows.reminder1).toBe(10)
-    expect(windows.reminder2).toBe(25)
-    expect(windows.timeout).toBe(40)
-
-    // Each stage leads to the next
-    expect(stages[0]).toBe("notified")
-    expect(stages[1]).toBe("reminder_1")
-    expect(stages[2]).toBe("reminder_2")
-    expect(stages[3]).toBe("timed_out")
+  it("points a normal 'notified' record at the 24h reminder", () => {
+    const dl = nextDeadline({
+      stage: "notified",
+      is_short_notice: false,
+      notified_at: NOTIFIED,
+    })
+    expect(dl?.nextStage).toBe("reminder_1")
+    expect(dl?.dueAt.getTime()).toBe(notifiedMs + 24 * MINUTES_PER_HOUR * 60 * 1000)
   })
 
-  it("short-notice flow uses compressed windows", () => {
-    const windows = SHORT_NOTICE_SLA_WINDOWS
+  it("points a normal 'reminder_1' record at the 48h timeout", () => {
+    const dl = nextDeadline({
+      stage: "reminder_1",
+      is_short_notice: false,
+      notified_at: NOTIFIED,
+    })
+    expect(dl?.nextStage).toBe("timed_out")
+    expect(dl?.dueAt.getTime()).toBe(notifiedMs + 48 * MINUTES_PER_HOUR * 60 * 1000)
+  })
 
-    // Compressed: 3min, 8min, 15min
-    expect(windows.reminder1).toBe(3)
-    expect(windows.reminder2).toBe(8)
-    expect(windows.timeout).toBe(15)
+  it("uses the compressed 4h/8h windows for short-notice records", () => {
+    const reminder = nextDeadline({
+      stage: "notified",
+      is_short_notice: true,
+      notified_at: NOTIFIED,
+    })
+    expect(reminder?.nextStage).toBe("reminder_1")
+    expect(reminder?.dueAt.getTime()).toBe(notifiedMs + 4 * MINUTES_PER_HOUR * 60 * 1000)
 
-    // Total time from notification to timeout
-    expect(windows.timeout).toBeLessThan(SHORT_NOTICE_THRESHOLD_MINUTES)
+    const timeout = nextDeadline({
+      stage: "reminder_1",
+      is_short_notice: true,
+      notified_at: NOTIFIED,
+    })
+    expect(timeout?.nextStage).toBe("timed_out")
+    expect(timeout?.dueAt.getTime()).toBe(notifiedMs + 8 * MINUTES_PER_HOUR * 60 * 1000)
+  })
+
+  it("escalates legacy 'reminder_2' records straight to timeout", () => {
+    const dl = nextDeadline({
+      stage: "reminder_2",
+      is_short_notice: false,
+      notified_at: NOTIFIED,
+    })
+    expect(dl?.nextStage).toBe("timed_out")
+    expect(dl?.dueAt.getTime()).toBe(notifiedMs + 48 * MINUTES_PER_HOUR * 60 * 1000)
+  })
+
+  it("returns null for terminal stages", () => {
+    for (const stage of ["timed_out", "confirmed", "rejected", "cancelled"] as const) {
+      expect(
+        nextDeadline({ stage, is_short_notice: false, notified_at: NOTIFIED })
+      ).toBeNull()
+    }
+  })
+
+  it("is a pure function — repeated calls yield identical deadlines", () => {
+    const input = {
+      stage: "notified" as const,
+      is_short_notice: false,
+      notified_at: NOTIFIED,
+    }
+    const a = nextDeadline(input)
+    const b = nextDeadline(input)
+    expect(a?.nextStage).toBe(b?.nextStage)
+    expect(a?.dueAt.getTime()).toBe(b?.dueAt.getTime())
+  })
+})
+
+describe("escalation flow / idempotency semantics", () => {
+  const NOTIFIED = "2026-03-05T08:00:00.000Z"
+  const notifiedMs = new Date(NOTIFIED).getTime()
+
+  // Mirrors the decision the cron makes: escalate only when now >= dueAt.
+  function isDue(
+    stage: "notified" | "reminder_1" | "reminder_2",
+    isShort: boolean,
+    now: number
+  ): boolean {
+    const dl = nextDeadline({ stage, is_short_notice: isShort, notified_at: NOTIFIED })
+    return dl !== null && now >= dl.dueAt.getTime()
+  }
+
+  it("normal flow is notified → reminder_1 → timed_out (single reminder)", () => {
+    // Just before 24h: nothing due.
+    expect(isDue("notified", false, notifiedMs + 23 * MS_PER_HOUR)).toBe(false)
+    // At 24h: reminder becomes due.
+    expect(isDue("notified", false, notifiedMs + 24 * MS_PER_HOUR)).toBe(true)
+    // After reminder sent, before 48h: timeout not yet due.
+    expect(isDue("reminder_1", false, notifiedMs + 47 * MS_PER_HOUR)).toBe(false)
+    // At 48h: timeout due.
+    expect(isDue("reminder_1", false, notifiedMs + 48 * MS_PER_HOUR)).toBe(true)
+  })
+
+  it("does not re-fire the reminder once the record advanced past 'notified'", () => {
+    // A second hourly cron run at 25h sees the record already at reminder_1.
+    // The reminder deadline no longer applies; only the 48h timeout can fire.
+    const now = notifiedMs + 25 * MS_PER_HOUR
+    expect(isDue("reminder_1", false, now)).toBe(false)
+  })
+
+  it("short-notice flow escalates on the 4h/8h schedule", () => {
+    expect(isDue("notified", true, notifiedMs + 3 * MS_PER_HOUR)).toBe(false)
+    expect(isDue("notified", true, notifiedMs + 4 * MS_PER_HOUR)).toBe(true)
+    expect(isDue("reminder_1", true, notifiedMs + 8 * MS_PER_HOUR)).toBe(true)
   })
 })

--- a/src/lib/acceptance/constants.ts
+++ b/src/lib/acceptance/constants.ts
@@ -1,27 +1,38 @@
 import type { AcceptanceStage, RejectionReason, SLAWindows } from "./types"
 
 /**
- * SLA windows for normal rides (pickup > 60 min from now).
- * Values in minutes after initial notification.
+ * One hour expressed in minutes.
+ * SLA windows are defined in hours (concept §3.3) but stored and compared in
+ * minutes so the escalation engine works on a single unit. Deriving the minute
+ * values from this constant keeps the intent readable and avoids magic numbers.
+ */
+export const MINUTES_PER_HOUR = 60
+
+/**
+ * SLA windows for normal rides (ride start >= 48h from now).
+ * Concept §3.3: reminder after 24h, dispatcher escalation after 48h.
+ * Values are minutes after the initial notification.
  */
 export const NORMAL_SLA_WINDOWS: SLAWindows = {
-  reminder1: 10,
-  reminder2: 25,
-  timeout: 40,
+  reminder1: 24 * MINUTES_PER_HOUR, // 24h → 1440 min
+  timeout: 48 * MINUTES_PER_HOUR, // 48h → 2880 min
 }
 
 /**
- * SLA windows for short-notice rides (pickup <= 60 min from now).
- * Shortened escalation times for urgent assignments.
+ * SLA windows for short-notice rides (ride start < 48h from now).
+ * Concept §3.3: shortened to a reminder after 4h and escalation after 8h.
+ * Values are minutes after the initial notification.
  */
 export const SHORT_NOTICE_SLA_WINDOWS: SLAWindows = {
-  reminder1: 3,
-  reminder2: 8,
-  timeout: 15,
+  reminder1: 4 * MINUTES_PER_HOUR, // 4h → 240 min
+  timeout: 8 * MINUTES_PER_HOUR, // 8h → 480 min
 }
 
-/** Threshold in minutes: pickup within this window = short notice */
-export const SHORT_NOTICE_THRESHOLD_MINUTES = 60
+/**
+ * Threshold in minutes: a ride whose start is closer than this is treated as
+ * short notice (concept §3.3: «Start < 48h = kurzfristig»). 48h = 2880 min.
+ */
+export const SHORT_NOTICE_THRESHOLD_MINUTES = 48 * MINUTES_PER_HOUR
 
 /** Active (non-terminal) stages for tracking queries */
 export const ACTIVE_STAGES: readonly AcceptanceStage[] = [

--- a/src/lib/acceptance/engine.ts
+++ b/src/lib/acceptance/engine.ts
@@ -1,4 +1,5 @@
 import { createAdminClient } from "@/lib/supabase/admin"
+import { zurichWallTimeToUtc } from "@/lib/utils/dates"
 import {
   NORMAL_SLA_WINDOWS,
   SHORT_NOTICE_SLA_WINDOWS,
@@ -10,18 +11,22 @@ import type {
   RejectionReason,
   ResolutionMethod,
   EscalationResult,
+  NextDeadline,
   SLAWindows,
 } from "./types"
 
+const MS_PER_MINUTE = 60 * 1000
+
 /**
- * Determine if a ride is short-notice based on pickup time.
- * Short-notice = pickup is less than 60 minutes from now.
+ * Determine if a ride is short-notice based on its start time.
+ * Short-notice = ride start is less than SHORT_NOTICE_THRESHOLD_MINUTES (48h)
+ * from now. The ride date + pickup time are wall-clock values in Europe/Zurich
+ * and are converted to an absolute instant so the comparison is timezone-safe
+ * (the server runtime is UTC).
  */
 export function isShortNotice(rideDate: string, pickupTime: string): boolean {
-  const pickupDateTime = new Date(`${rideDate}T${pickupTime}`)
-  const now = new Date()
-  const diffMs = pickupDateTime.getTime() - now.getTime()
-  const diffMinutes = diffMs / (1000 * 60)
+  const pickupInstantMs = zurichWallTimeToUtc(rideDate, pickupTime).getTime()
+  const diffMinutes = (pickupInstantMs - Date.now()) / MS_PER_MINUTE
   return diffMinutes < SHORT_NOTICE_THRESHOLD_MINUTES
 }
 
@@ -30,6 +35,44 @@ export function isShortNotice(rideDate: string, pickupTime: string): boolean {
  */
 export function getSLAWindows(shortNotice: boolean): SLAWindows {
   return shortNotice ? SHORT_NOTICE_SLA_WINDOWS : NORMAL_SLA_WINDOWS
+}
+
+/** Minimal shape needed to compute a deadline (subset of acceptance_tracking). */
+export interface DeadlineInput {
+  stage: AcceptanceStage
+  is_short_notice: boolean
+  notified_at: string
+}
+
+/**
+ * Compute the next escalation deadline for a tracking record.
+ *
+ * Single source of truth shared by the cron engine (below) and the UI countdown
+ * on ride cards, so both compute identical deadlines from the same SLA windows.
+ * Returns null for terminal stages or stages with nothing left to escalate.
+ *
+ * Note: per concept §3.3 the flow is `notified → reminder_1 → timed_out`
+ * (one reminder). Legacy `reminder_2` records still escalate to `timed_out`.
+ */
+export function nextDeadline(tracking: DeadlineInput): NextDeadline | null {
+  const windows = getSLAWindows(tracking.is_short_notice)
+  const notifiedAtMs = new Date(tracking.notified_at).getTime()
+
+  switch (tracking.stage) {
+    case "notified":
+      return {
+        nextStage: "reminder_1",
+        dueAt: new Date(notifiedAtMs + windows.reminder1 * MS_PER_MINUTE),
+      }
+    case "reminder_1":
+    case "reminder_2":
+      return {
+        nextStage: "timed_out",
+        dueAt: new Date(notifiedAtMs + windows.timeout * MS_PER_MINUTE),
+      }
+    default:
+      return null
+  }
 }
 
 /**
@@ -187,81 +230,77 @@ export async function checkPendingAcceptances(): Promise<EscalationResult[]> {
   const now = Date.now()
 
   for (const tracking of trackings) {
-    const windows = getSLAWindows(tracking.is_short_notice)
-    const notifiedAt = new Date(tracking.notified_at).getTime()
-    const minutesSinceNotified = (now - notifiedAt) / (1000 * 60)
-
-    let nextStage: AcceptanceStage | null = null
     const currentStage = tracking.stage as AcceptanceStage
 
-    if (
-      currentStage === "notified" &&
-      minutesSinceNotified >= windows.reminder1
-    ) {
-      nextStage = "reminder_1"
-    } else if (
-      currentStage === "reminder_1" &&
-      minutesSinceNotified >= windows.reminder2
-    ) {
-      nextStage = "reminder_2"
-    } else if (
-      currentStage === "reminder_2" &&
-      minutesSinceNotified >= windows.timeout
-    ) {
-      nextStage = "timed_out"
+    // Shared deadline logic (UI countdown uses the same function).
+    const deadline = nextDeadline({
+      stage: currentStage,
+      is_short_notice: tracking.is_short_notice,
+      notified_at: tracking.notified_at,
+    })
+
+    // Nothing to escalate yet, or stage is terminal.
+    if (!deadline || now < deadline.dueAt.getTime()) {
+      continue
     }
 
-    if (nextStage) {
-      const escalated = await escalateToStage(
-        tracking.id,
-        currentStage,
-        nextStage
-      )
+    const nextStage = deadline.nextStage
 
-      results.push({
-        trackingId: tracking.id,
-        rideId: tracking.ride_id,
-        driverId: tracking.driver_id,
-        fromStage: currentStage,
-        toStage: nextStage,
-        escalated,
-      })
+    // Atomic, conditional transition — only succeeds if the stage is still the
+    // one we observed (SEC-M9-004 / #186). Guarantees exactly-once escalation
+    // even when the cron overlaps or runs more frequently.
+    const escalated = await escalateToStage(
+      tracking.id,
+      currentStage,
+      nextStage
+    )
 
-      // Send reminder emails for reminder stages
-      if (escalated && (nextStage === "reminder_1" || nextStage === "reminder_2")) {
-        try {
-          const { sendDriverReminder } = await import(
-            "@/lib/mail/templates/driver-reminder"
-          )
-          await sendDriverReminder(
-            tracking.ride_id,
-            tracking.driver_id,
-            nextStage
-          )
-        } catch (err) {
-          console.error(
-            `Failed to send reminder for tracking ${tracking.id}:`,
-            err
-          )
-        }
+    results.push({
+      trackingId: tracking.id,
+      rideId: tracking.ride_id,
+      driverId: tracking.driver_id,
+      fromStage: currentStage,
+      toStage: nextStage,
+      escalated,
+    })
+
+    // Only the process that won the atomic transition (escalated === true)
+    // sends mail, so reminders/escalations are dispatched exactly once (#186).
+
+    // Send reminder email for the reminder stage.
+    if (escalated && (nextStage === "reminder_1" || nextStage === "reminder_2")) {
+      try {
+        const { sendDriverReminder } = await import(
+          "@/lib/mail/templates/driver-reminder"
+        )
+        await sendDriverReminder(
+          tracking.ride_id,
+          tracking.driver_id,
+          nextStage
+        )
+      } catch (err) {
+        console.error(
+          `Failed to send reminder for tracking ${tracking.id}:`,
+          err
+        )
       }
+    }
 
-      // Send dispatcher escalation for timeout
-      if (escalated && nextStage === "timed_out") {
-        try {
-          const { sendDispatcherEscalation } = await import(
-            "@/lib/mail/templates/dispatcher-escalation"
-          )
-          await sendDispatcherEscalation(
-            tracking.ride_id,
-            tracking.driver_id
-          )
-        } catch (err) {
-          console.error(
-            `Failed to send escalation for tracking ${tracking.id}:`,
-            err
-          )
-        }
+    // Send dispatcher escalation for timeout.
+    if (escalated && nextStage === "timed_out") {
+      try {
+        const { sendDispatcherEscalation } = await import(
+          "@/lib/mail/templates/dispatcher-escalation"
+        )
+        await sendDispatcherEscalation(
+          tracking.ride_id,
+          tracking.driver_id
+        )
+      } catch (err) {
+        console.error(
+          `Failed to send escalation for tracking ${tracking.id}:`,
+          err
+        )
       }
     }
   }

--- a/src/lib/acceptance/types.ts
+++ b/src/lib/acceptance/types.ts
@@ -3,6 +3,12 @@ import type { Tables } from "@/lib/types/database"
 export type AcceptanceStage =
   | "notified"
   | "reminder_1"
+  /**
+   * @deprecated Concept §3.3 defines a single reminder followed by escalation,
+   * so the engine no longer transitions into `reminder_2`. The value is kept
+   * because it still exists in the DB enum; legacy records at this stage are
+   * still escalated to `timed_out`.
+   */
   | "reminder_2"
   | "timed_out"
   | "confirmed"
@@ -25,11 +31,9 @@ export type ResolutionMethod =
 export type AcceptanceTracking = Tables<"acceptance_tracking">
 
 export interface SLAWindows {
-  /** Minutes after notification for reminder 1 */
+  /** Minutes after notification until the single reminder is sent (concept §3.3). */
   reminder1: number
-  /** Minutes after notification for reminder 2 */
-  reminder2: number
-  /** Minutes after notification for timeout */
+  /** Minutes after notification until dispatcher escalation (timeout). */
   timeout: number
 }
 
@@ -40,4 +44,16 @@ export interface EscalationResult {
   fromStage: AcceptanceStage
   toStage: AcceptanceStage
   escalated: boolean
+}
+
+/**
+ * The next pending escalation for an active tracking record.
+ * Shared between the cron engine and the UI countdown so both compute the
+ * same deadline from the same SLA windows.
+ */
+export interface NextDeadline {
+  /** Stage the record transitions into once `dueAt` passes. */
+  nextStage: AcceptanceStage
+  /** Absolute instant at which the next escalation becomes due. */
+  dueAt: Date
 }

--- a/src/lib/mail/templates/dispatcher-escalation.ts
+++ b/src/lib/mail/templates/dispatcher-escalation.ts
@@ -3,13 +3,27 @@ import { mailTransport } from "@/lib/mail/transport"
 import { escapeHtml, formatDate, formatTime } from "@/lib/mail/utils"
 import { getAppUrl } from "@/lib/acceptance/constants"
 
+/**
+ * Short, non-identifying ride reference. Format: F-YYMMDD-last4
+ * (matches the order-sheet reference, e.g. F-260225-a3f1).
+ */
+function formatRideRef(date: string, rideId: string): string {
+  const [yyyy = "", mm = "", dd = ""] = date.split("-")
+  return `F-${yyyy.slice(2)}${mm}${dd}-${rideId.slice(-4)}`
+}
+
+/**
+ * Data for the dispatcher escalation mail.
+ * SEC #186 / data minimization: NO patient PII. The mail carries only the ride
+ * reference, time, a coarse region, and a deep link into the authenticated app
+ * where the dispatcher sees full details.
+ */
 interface EscalationEmailData {
   driverName: string
-  patientName: string
-  destinationName: string
+  rideRef: string
+  region: string
   date: string // Already formatted
   pickupTime: string
-  direction: string // Raw enum value (unused in escalation, kept for consistency)
   dispatchUrl: string
 }
 
@@ -19,10 +33,10 @@ function dispatcherEscalationEmail(data: EscalationEmailData): {
 } {
   const subject = `Zeitueberschreitung: Fahrt am ${data.date} – Fahrer hat nicht reagiert`
 
-  // Escape all user-provided data for XSS protection
+  // Escape all dynamic data for XSS protection
   const driverName = escapeHtml(data.driverName)
-  const patientName = escapeHtml(data.patientName)
-  const destinationName = escapeHtml(data.destinationName)
+  const rideRef = escapeHtml(data.rideRef)
+  const region = escapeHtml(data.region)
   const date = escapeHtml(data.date)
   const pickupTime = escapeHtml(formatTime(data.pickupTime))
 
@@ -67,16 +81,16 @@ function dispatcherEscalationEmail(data: EscalationEmailData): {
                   <td style="padding:6px 16px;">
                     <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
                       <tr>
-                        <td style="color:#71717a;font-size:13px;padding:4px 0;width:100px;">Fahrer</td>
+                        <td style="color:#71717a;font-size:13px;padding:4px 0;width:100px;">Fahrt-Ref.</td>
+                        <td style="color:#18181b;font-size:14px;font-weight:500;padding:4px 0;">${rideRef}</td>
+                      </tr>
+                      <tr>
+                        <td style="color:#71717a;font-size:13px;padding:4px 0;">Fahrer</td>
                         <td style="color:#18181b;font-size:14px;font-weight:500;padding:4px 0;">${driverName}</td>
                       </tr>
                       <tr>
-                        <td style="color:#71717a;font-size:13px;padding:4px 0;">Patient</td>
-                        <td style="color:#18181b;font-size:14px;font-weight:500;padding:4px 0;">${patientName}</td>
-                      </tr>
-                      <tr>
-                        <td style="color:#71717a;font-size:13px;padding:4px 0;">Ziel</td>
-                        <td style="color:#18181b;font-size:14px;font-weight:500;padding:4px 0;">${destinationName}</td>
+                        <td style="color:#71717a;font-size:13px;padding:4px 0;">Region</td>
+                        <td style="color:#18181b;font-size:14px;font-weight:500;padding:4px 0;">${region}</td>
                       </tr>
                       <tr>
                         <td style="color:#71717a;font-size:13px;padding:4px 0;">Datum</td>
@@ -131,13 +145,13 @@ export async function sendDispatcherEscalation(
 ): Promise<void> {
   const supabase = createAdminClient()
 
-  // Load ride with patient and destination
+  // Data minimization (#186): only load a coarse region (destination city),
+  // never patient names or the full destination for the escalation mail.
   const { data: ride } = await supabase
     .from("rides")
     .select(`
-      id, date, pickup_time, direction,
-      patients!inner(first_name, last_name),
-      destinations!inner(display_name)
+      id, date, pickup_time,
+      destinations!inner(city, postal_code)
     `)
     .eq("id", rideId)
     .single()
@@ -174,16 +188,19 @@ export async function sendDispatcherEscalation(
     return
   }
 
-  const patient = ride.patients as unknown as { first_name: string; last_name: string }
-  const destination = ride.destinations as unknown as { display_name: string }
+  const destination = ride.destinations as unknown as {
+    city: string | null
+    postal_code: string | null
+  }
+  // Coarse region only — city, or postal code as fallback, never a full address.
+  const region = destination.city ?? destination.postal_code ?? "Unbekannt"
 
   const { subject, html } = dispatcherEscalationEmail({
     driverName: `${driver.first_name} ${driver.last_name}`,
-    patientName: `${patient.first_name} ${patient.last_name}`,
-    destinationName: destination.display_name,
+    rideRef: formatRideRef(ride.date, ride.id),
+    region,
     date: formatDate(ride.date),
     pickupTime: ride.pickup_time,
-    direction: ride.direction,
     dispatchUrl: `${appUrl}/dispatch?date=${ride.date}`,
   })
 

--- a/src/lib/utils/dates.ts
+++ b/src/lib/utils/dates.ts
@@ -4,6 +4,41 @@
  * dispatch-board.tsx, and dashboard/page.tsx.
  */
 
+/** IANA timezone the business operates in. Ride dates/times are wall-clock in this zone. */
+export const APP_TIME_ZONE = "Europe/Zurich"
+
+/**
+ * Offset in milliseconds between the given timezone and UTC at a specific instant.
+ * Positive when the zone is ahead of UTC (e.g. +1h CET, +2h CEST).
+ */
+function timeZoneOffsetMs(instant: Date, timeZone: string): number {
+  // `toLocaleString` re-renders the instant as wall-clock text in each zone;
+  // re-parsing both as local Dates and subtracting yields the zone offset.
+  const utcWall = new Date(instant.toLocaleString("en-US", { timeZone: "UTC" }))
+  const zoneWall = new Date(instant.toLocaleString("en-US", { timeZone }))
+  return zoneWall.getTime() - utcWall.getTime()
+}
+
+/**
+ * Interpret a naive date + time as Europe/Zurich wall-clock time and return the
+ * corresponding absolute instant (a UTC Date). DST (CET/CEST) is handled via the
+ * Intl timezone database, so callers must never assume a fixed +1/+2h offset.
+ *
+ * Server runtimes (Vercel) run in UTC, so parsing `new Date("2026-03-05T10:00:00")`
+ * would silently mislabel a Zurich ride by the zone offset — this helper fixes that.
+ *
+ * @param dateStr YYYY-MM-DD
+ * @param timeStr HH:mm or HH:mm:ss
+ */
+export function zurichWallTimeToUtc(dateStr: string, timeStr: string): Date {
+  // Treat the wall time as if it were UTC, then subtract the real zone offset.
+  // Using the offset at this (approximate) instant is exact except within the
+  // ~1h DST transition windows, which is irrelevant for our hour-scale SLAs.
+  const asIfUtc = new Date(`${dateStr}T${timeStr}Z`)
+  const offsetMs = timeZoneOffsetMs(asIfUtc, APP_TIME_ZONE)
+  return new Date(asIfUtc.getTime() - offsetMs)
+}
+
 /** Get today as YYYY-MM-DD. */
 export function getToday(): string {
   return new Date().toISOString().split("T")[0]!

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/acceptance-check",
-      "schedule": "0 6 * * *"
+      "schedule": "0 * * * *"
     },
     {
       "path": "/api/cron/geocode-backfill",

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/acceptance-check",
-      "schedule": "0 * * * *"
+      "schedule": "0 6 * * *"
     },
     {
       "path": "/api/cron/geocode-backfill",


### PR DESCRIPTION
## Was & Warum

Setzt Issue #165 (M15, Phase 15.1) um. Die SLA-Fenster standen noch auf Prototyp-Minuten (10/25/40 min). Laut Konzept §3.3 gilt jetzt: **Erinnerung nach 24h, Dispo-Eskalation nach 48h**; bei kurzfristigen Fahrten (Start < 48h) verkürzt auf **4h / 8h**.

## Änderungen

- **`constants.ts`**: `NORMAL_SLA_WINDOWS` = 24h/48h, `SHORT_NOTICE_SLA_WINDOWS` = 4h/8h, `SHORT_NOTICE_THRESHOLD_MINUTES` = 48h (2880 min). Alle Werte aus `MINUTES_PER_HOUR` abgeleitet — keine Magic Numbers.
- **Eine Erinnerungsstufe**: Flow ist jetzt `notified → reminder_1 → timed_out`. `reminder_2` ist als `@deprecated` dokumentiert (bleibt im DB-Enum; Legacy-Records eskalieren weiterhin sauber zu `timed_out`), es wird aber keine neue `reminder_2`-Transition mehr erzeugt.
- **`nextDeadline(tracking)`**: neue, einzige Quelle der Fenster-Logik. Cron-Engine und der (separate) UI-Countdown rechnen damit identisch.
- **`isShortNotice`**: Fahrtstart wird timezone-sicher aus Europe/Zurich abgeleitet (neuer DST-aware Helper `zurichWallTimeToUtc` in `lib/utils/dates.ts`) statt der bisherigen naiven UTC-Interpretation — auf dem UTC-Runtime (Vercel) sonst um den Zonen-Offset verschoben.

## Cron-Kadenz (Vercel-Hobby-Limit)

Der Acceptance-Cron **bleibt täglich** (`0 6 * * *`). Der Vercel-Hobby-Plan erlaubt nur tägliche Crons — bewusste Entscheidung (kein Plan-Upgrade, kein externer Scheduler). Konsequenzen, ehrlich dokumentiert im Route-Kommentar:
- Die 24h/48h-Normalfenster werden nur mit **Tages-Granularität** getroffen (ein Record, der seine Deadline überschreitet, wird beim nächsten 06:00-Lauf eskaliert).
- Die **4h/8h-Kurzfrist-Eskalation** kann der Tages-Cron nicht bedienen; sie wird primär vom Fire-and-forget-Aufruf `checkPendingAcceptances()` beim Laden der Dispatch-Seite getragen (fängt fällige Deadlines über den Arbeitstag ab).

Die SLA-Fenster-Logik selbst ist unabhängig von der Kadenz korrekt.

## Security (#186)

- **Exactly-once**: Stage-Übergänge bleiben atomar (bedingtes `UPDATE ... WHERE stage = expected`). Nur der Lauf, der die Transition gewinnt, verschickt Mail — keine Doppel-Erinnerungen/-Eskalationen. Idempotenz durch Tests abgedeckt.
- **Datenminimierung Dispo-Alarm-Mail**: keine Patienten-PII mehr. Enthält nur noch Fahrt-Referenz (`F-YYMMDD-xxxx`), Region (Ort der Destination), Datum/Zeit, Fahrername (Staff) und einen Deep-Link in die authentifizierte Dispo-App.
- **Cron** bleibt `CRON_SECRET`-gated; Response/Logs enthalten nur opake UUIDs, keine PII.
- **Kurzfrist-Fristen** korrekt aus Fahrtstart abgeleitet, Zeitzonen (CET/CEST) über die Intl-Zonendatenbank.

## Tests / Checks

- `npx tsc --noEmit`: grün
- `npm run lint`: grün (nur vorbestehende Warnings in unbezogenen Dateien)
- `vitest run`: **1025 Tests grün**. Neue Tests: Fenster-Werte, 48h-Kurzfrist-Schwelle inkl. Grenzfall, DST-Konvertierung (CET & CEST), `nextDeadline`-Verhalten (normal/kurzfristig/Legacy/terminal) und Idempotenz-Semantik.

Keine DB-Migration nötig — reine Konstanten-/Logik-/Konfigurationsänderung. `acceptance_tracking` wird nur lesend/mit vorhandenen Spalten genutzt.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)
