### PR TITLE
feat(m15): Rückfahrt-Mitanfrage — verknüpftes Leg in einer Aktion zuweisen (#167)

### DIFF
--- a/src/actions/__tests__/assign-driver-with-return.test.ts
+++ b/src/actions/__tests__/assign-driver-with-return.test.ts
@@ -1,0 +1,363 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import type { DriverDayStatus } from "@/lib/availability/driver-status"
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// rides.ts transitively imports a `server-only` module (availability guard).
+vi.mock("server-only", () => ({}))
+
+interface RideRow {
+  id: string
+  status: string
+  driver_id: string | null
+  date: string
+  pickup_time: string
+  parent_ride_id: string | null
+}
+
+const store = vi.hoisted(() => ({
+  rows: new Map<string, RideRow>(),
+  updateError: null as string | null,
+  updateCalls: [] as Array<{ id: string; data: Record<string, unknown> }>,
+}))
+
+// Minimal stateful Supabase mock that routes by table + chained ops.
+function makeRidesBuilder() {
+  const state: {
+    op: "select" | "update" | null
+    filters: Record<string, unknown>
+    updateData: Record<string, unknown> | null
+  } = { op: null, filters: {}, updateData: null }
+
+  const builder = {
+    select() {
+      state.op = "select"
+      return builder
+    },
+    update(data: Record<string, unknown>) {
+      state.op = "update"
+      state.updateData = data
+      return builder
+    },
+    eq(col: string, val: unknown) {
+      state.filters[col] = val
+      if (state.op === "update") {
+        const id = String(val)
+        store.updateCalls.push({ id, data: state.updateData ?? {} })
+        if (store.updateError) {
+          return Promise.resolve({ error: { message: store.updateError } })
+        }
+        const row = store.rows.get(id)
+        if (row) Object.assign(row, state.updateData)
+        return Promise.resolve({ error: null })
+      }
+      return builder
+    },
+    single() {
+      return Promise.resolve(resolveSelect(state))
+    },
+    maybeSingle() {
+      return Promise.resolve(resolveSelect(state))
+    },
+  }
+  return builder
+}
+
+function resolveSelect(state: { filters: Record<string, unknown> }) {
+  if ("parent_ride_id" in state.filters) {
+    const pid = state.filters.parent_ride_id
+    const child = [...store.rows.values()].find(
+      (r) => r.parent_ride_id === pid
+    )
+    return { data: child ? { id: child.id } : null }
+  }
+  const id = String(state.filters.id)
+  const row = store.rows.get(id)
+  return { data: row ? { ...row } : null }
+}
+
+const genericBuilder = {
+  insert: () => Promise.resolve({ error: null }),
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    from: (table: string) =>
+      table === "rides" ? makeRidesBuilder() : genericBuilder,
+  }),
+}))
+
+vi.mock("@/lib/auth/require-auth", () => ({
+  requireAuth: vi.fn(),
+}))
+
+const { mockGetDriverDayStatus } = vi.hoisted(() => ({
+  mockGetDriverDayStatus: vi.fn(),
+}))
+
+vi.mock("@/lib/availability/assignment", () => ({
+  getDriverDayStatus: mockGetDriverDayStatus,
+  logOutsideAvailabilityAssignment: vi.fn().mockResolvedValue(undefined),
+}))
+
+const {
+  mockInvalidateTokens,
+  mockSendNotification,
+  mockCreateTracking,
+  mockRecordEvent,
+  mockLogAudit,
+  mockAcceptanceEnabled,
+} = vi.hoisted(() => ({
+  mockInvalidateTokens: vi.fn().mockResolvedValue(undefined),
+  mockSendNotification: vi.fn().mockResolvedValue(undefined),
+  mockCreateTracking: vi.fn().mockResolvedValue(undefined),
+  mockRecordEvent: vi.fn().mockResolvedValue(undefined),
+  mockLogAudit: vi.fn().mockResolvedValue(undefined),
+  mockAcceptanceEnabled: vi.fn().mockReturnValue(true),
+}))
+
+vi.mock("@/lib/mail/tokens", () => ({
+  invalidateTokensForRide: mockInvalidateTokens,
+}))
+vi.mock("@/lib/mail/send-driver-notification", () => ({
+  sendDriverNotification: mockSendNotification,
+}))
+vi.mock("@/lib/acceptance/engine", () => ({
+  createAcceptanceTracking: mockCreateTracking,
+  cancelAcceptanceTracking: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock("@/lib/acceptance/events", () => ({
+  recordAssignmentEvent: mockRecordEvent,
+}))
+vi.mock("@/lib/acceptance/constants", () => ({
+  isAcceptanceFlowEnabled: mockAcceptanceEnabled,
+}))
+vi.mock("@/lib/audit/logger", () => ({
+  logAudit: mockLogAudit,
+}))
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}))
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { assignDriverWithReturn } from "../rides"
+import { requireAuth } from "@/lib/auth/require-auth"
+
+const mockRequireAuth = vi.mocked(requireAuth)
+
+const OUTBOUND = "11111111-1111-4111-8111-111111111111"
+const RETURN = "22222222-2222-4222-8222-222222222222"
+const DRIVER = "99999999-9999-4999-8999-999999999999"
+
+function statusOk(): DriverDayStatus {
+  return {
+    isAbsent: false,
+    absenceType: null,
+    windows: [],
+    hasAvailability: true,
+    isWithinAvailability: true,
+  }
+}
+function statusAbsent(): DriverDayStatus {
+  return {
+    isAbsent: true,
+    absenceType: "vacation",
+    windows: [],
+    hasAvailability: false,
+    isWithinAvailability: false,
+  }
+}
+
+function seedLinkedPair() {
+  store.rows.set(OUTBOUND, {
+    id: OUTBOUND,
+    status: "unplanned",
+    driver_id: null,
+    date: "2026-08-01",
+    pickup_time: "09:00:00",
+    parent_ride_id: null,
+  })
+  store.rows.set(RETURN, {
+    id: RETURN,
+    status: "unplanned",
+    driver_id: null,
+    date: "2026-08-01",
+    pickup_time: "11:00:00",
+    parent_ride_id: OUTBOUND,
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  store.rows.clear()
+  store.updateError = null
+  store.updateCalls = []
+  mockAcceptanceEnabled.mockReturnValue(true)
+  mockGetDriverDayStatus.mockResolvedValue(statusOk())
+  mockRequireAuth.mockResolvedValue({
+    authorized: true,
+    userId: "user-1",
+    role: "operator",
+    driverId: null,
+  })
+})
+
+describe("assignDriverWithReturn", () => {
+  it("co-assigns both legs from the outbound leg in one action", async () => {
+    seedLinkedPair()
+
+    const result = await assignDriverWithReturn(OUTBOUND, DRIVER, {
+      includeReturn: true,
+    })
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.returnLegAssigned).toBe(true)
+    expect(result.data.assignedRideIds).toEqual(
+      expect.arrayContaining([OUTBOUND, RETURN])
+    )
+    expect(result.data.assignedRideIds).toHaveLength(2)
+
+    // Both legs updated to the driver + planned.
+    expect(store.rows.get(OUTBOUND)?.driver_id).toBe(DRIVER)
+    expect(store.rows.get(OUTBOUND)?.status).toBe("planned")
+    expect(store.rows.get(RETURN)?.driver_id).toBe(DRIVER)
+    expect(store.rows.get(RETURN)?.status).toBe("planned")
+
+    // One request event + one tracking per leg (two separate mails, MVP).
+    expect(mockRecordEvent).toHaveBeenCalledTimes(2)
+    expect(mockCreateTracking).toHaveBeenCalledTimes(2)
+    expect(mockSendNotification).toHaveBeenCalledTimes(2)
+    expect(mockSendNotification).toHaveBeenCalledWith(OUTBOUND, DRIVER)
+    expect(mockSendNotification).toHaveBeenCalledWith(RETURN, DRIVER)
+  })
+
+  it("resolves the linked leg from the return leg (bidirectional)", async () => {
+    seedLinkedPair()
+
+    const result = await assignDriverWithReturn(RETURN, DRIVER, {
+      includeReturn: true,
+    })
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.assignedRideIds).toEqual(
+      expect.arrayContaining([OUTBOUND, RETURN])
+    )
+    expect(store.rows.get(OUTBOUND)?.driver_id).toBe(DRIVER)
+    expect(store.rows.get(RETURN)?.driver_id).toBe(DRIVER)
+  })
+
+  it("assigns nothing when the driver is absent for the RETURN leg", async () => {
+    seedLinkedPair()
+    // Absent only at the return leg's pickup time.
+    mockGetDriverDayStatus.mockImplementation(
+      async (_c: unknown, _d: string, _date: string, time: string) =>
+        time === "11:00:00" ? statusAbsent() : statusOk()
+    )
+
+    const result = await assignDriverWithReturn(OUTBOUND, DRIVER, {
+      includeReturn: true,
+    })
+
+    expect(result.success).toBe(false)
+    // Nothing was written to any leg.
+    expect(store.updateCalls).toHaveLength(0)
+    expect(store.rows.get(OUTBOUND)?.driver_id).toBeNull()
+    expect(store.rows.get(RETURN)?.driver_id).toBeNull()
+    expect(mockRecordEvent).not.toHaveBeenCalled()
+    expect(mockCreateTracking).not.toHaveBeenCalled()
+  })
+
+  it("assigns only the primary leg when no linked leg exists", async () => {
+    store.rows.set(OUTBOUND, {
+      id: OUTBOUND,
+      status: "unplanned",
+      driver_id: null,
+      date: "2026-08-01",
+      pickup_time: "09:00:00",
+      parent_ride_id: null,
+    })
+
+    const result = await assignDriverWithReturn(OUTBOUND, DRIVER, {
+      includeReturn: true,
+    })
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.returnLegAssigned).toBe(false)
+    expect(result.data.returnLegSkippedReason).toBe("no_linked_leg")
+    expect(result.data.assignedRideIds).toEqual([OUTBOUND])
+    expect(mockRecordEvent).toHaveBeenCalledTimes(1)
+    expect(mockCreateTracking).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not co-assign a linked leg that is already completed", async () => {
+    seedLinkedPair()
+    store.rows.get(RETURN)!.status = "completed"
+
+    const result = await assignDriverWithReturn(OUTBOUND, DRIVER, {
+      includeReturn: true,
+    })
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.returnLegAssigned).toBe(false)
+    expect(result.data.returnLegSkippedReason).toBe("not_assignable")
+    expect(result.data.assignedRideIds).toEqual([OUTBOUND])
+    // Return leg untouched.
+    expect(store.rows.get(RETURN)?.driver_id).toBeNull()
+    expect(store.rows.get(RETURN)?.status).toBe("completed")
+  })
+
+  it("does not touch the linked leg when includeReturn is false", async () => {
+    seedLinkedPair()
+
+    const result = await assignDriverWithReturn(OUTBOUND, DRIVER, {
+      includeReturn: false,
+    })
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.returnLegAssigned).toBe(false)
+    expect(result.data.assignedRideIds).toEqual([OUTBOUND])
+    expect(store.rows.get(RETURN)?.driver_id).toBeNull()
+  })
+
+  it("rolls back the applied leg when the second leg's write fails", async () => {
+    seedLinkedPair()
+    // Fail all updates -> first apply fails immediately, nothing persists.
+    store.updateError = "db down"
+
+    const result = await assignDriverWithReturn(OUTBOUND, DRIVER, {
+      includeReturn: true,
+    })
+
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toContain("Zuweisung fehlgeschlagen")
+    // No side effects fired because writes failed before the side-effect phase.
+    expect(mockRecordEvent).not.toHaveBeenCalled()
+    expect(mockCreateTracking).not.toHaveBeenCalled()
+  })
+
+  it("rejects unauthenticated callers", async () => {
+    mockRequireAuth.mockResolvedValue({
+      authorized: false,
+      error: "Nicht authentifiziert",
+    })
+
+    const result = await assignDriverWithReturn(OUTBOUND, DRIVER, {
+      includeReturn: true,
+    })
+
+    expect(result.success).toBe(false)
+    if (result.success) return
+    expect(result.error).toBe("Nicht authentifiziert")
+  })
+})

--- a/src/actions/rides.ts
+++ b/src/actions/rides.ts
@@ -32,6 +32,13 @@ import type { DriverDayStatus } from "@/lib/availability/driver-status"
 import { trackEvent } from "@/lib/telemetry"
 import { uuidSchema } from "@/lib/validations/shared"
 import { collectRideWarnings } from "@/lib/rides/warnings"
+import {
+  planCoAssignment,
+  resolveLinkedLegId,
+  isCoAssignable,
+  type CoAssignLegState,
+  type LegRole,
+} from "@/lib/rides/co-assign"
 import type { ActionResult, ActionWarning } from "@/actions/shared"
 import type { Tables, TablesInsert, Enums, Json } from "@/lib/types/database"
 import type { RideRequirement } from "@/lib/rides/requirements"
@@ -1313,6 +1320,293 @@ export async function assignDriver(
   revalidatePath("/rides")
   revalidatePath("/my/rides")
   return { success: true, data: undefined }
+}
+
+/** Columns needed to plan + apply a co-assignment for one leg. */
+interface CoAssignLegRow {
+  id: string
+  status: Enums<"ride_status">
+  driver_id: string | null
+  date: string
+  pickup_time: string
+  parent_ride_id: string | null
+}
+
+const CO_ASSIGN_LEG_COLUMNS =
+  "id, status, driver_id, date, pickup_time, parent_ride_id"
+
+/** Result of {@link assignDriverWithReturn}: which legs actually got assigned. */
+export interface AssignWithReturnResult {
+  /** Ride ids that were (re)assigned to the driver in this operation. */
+  assignedRideIds: string[]
+  /** Whether the linked return leg was co-assigned. */
+  returnLegAssigned: boolean
+  /**
+   * Set when `includeReturn` was requested but the linked leg was skipped
+   * because it is in a non-assignable status (terminal / already underway).
+   */
+  returnLegSkippedReason?: "not_assignable" | "no_linked_leg"
+}
+
+/**
+ * Assign a driver to a ride and, on request, to its linked return leg in one
+ * atomic action (Issue #167, concept §2.1/§2.3).
+ *
+ * The link is `rides.parent_ride_id` (self-FK, return → outbound); the linked
+ * leg is resolved in both directions. Security rule #182: the absence/conflict
+ * guard runs for *every* leg before anything is written — if any leg fails hard
+ * (driver absent), nothing is assigned and a speaking error is returned. If a
+ * DB write fails mid-way, already-applied legs are rolled back.
+ *
+ * Mail variant (documented per issue): MVP = one separate request mail + one
+ * token + one `acceptance_tracking` per leg. A single bundled double-token mail
+ * is a possible follow-up.
+ *
+ * `driverId` must be non-null — this action only assigns. Driver removal keeps
+ * going through {@link assignDriver}.
+ */
+export async function assignDriverWithReturn(
+  rideId: string,
+  driverId: string,
+  options: { includeReturn: boolean }
+): Promise<ActionResult<AssignWithReturnResult>> {
+  uuidSchema.parse(rideId)
+  uuidSchema.parse(driverId)
+
+  const auth = await requireAuth(["admin", "operator"])
+  if (!auth.authorized) {
+    return { success: false, error: auth.error }
+  }
+
+  const supabase = await createClient()
+
+  // 1) Load the primary leg the dispatcher explicitly picked.
+  const { data: primaryRow } = await supabase
+    .from("rides")
+    .select(CO_ASSIGN_LEG_COLUMNS)
+    .eq("id", rideId)
+    .single<CoAssignLegRow>()
+
+  if (!primaryRow) {
+    return { success: false, error: "Fahrt nicht gefunden" }
+  }
+
+  // 2) Resolve the linked return leg (both directions) when requested.
+  let linkedRow: CoAssignLegRow | null = null
+  let skippedReason: AssignWithReturnResult["returnLegSkippedReason"]
+
+  if (options.includeReturn) {
+    let linkedId = resolveLinkedLegId(primaryRow, null)
+
+    // Outbound leg: the linked return leg points back at us via parent_ride_id.
+    if (!linkedId) {
+      const { data: childRow } = await supabase
+        .from("rides")
+        .select("id")
+        .eq("parent_ride_id", rideId)
+        .maybeSingle()
+      linkedId = childRow?.id ?? null
+    }
+
+    if (!linkedId) {
+      skippedReason = "no_linked_leg"
+    } else {
+      const { data: fetchedLinked } = await supabase
+        .from("rides")
+        .select(CO_ASSIGN_LEG_COLUMNS)
+        .eq("id", linkedId)
+        .single<CoAssignLegRow>()
+
+      if (fetchedLinked && isCoAssignable(fetchedLinked.status)) {
+        linkedRow = fetchedLinked
+      } else {
+        // Linked leg exists but is terminal / already underway — never clobber
+        // it. The primary assignment still proceeds.
+        skippedReason = "not_assignable"
+      }
+    }
+  }
+
+  // 3) Build the leg list and compute the absence/conflict guard for EACH leg
+  //    (security #182) BEFORE mutating anything.
+  const legRows: Array<{ row: CoAssignLegRow; role: LegRole }> = [
+    { row: primaryRow, role: "primary" },
+  ]
+  if (linkedRow) legRows.push({ row: linkedRow, role: "return" })
+
+  const guardByRide = new Map<string, DriverDayStatus | null>()
+  const legStates: CoAssignLegState[] = []
+
+  for (const { row, role } of legRows) {
+    let driverStatus: DriverDayStatus | null = null
+    // Only guard when a *different* driver is being assigned (matches the
+    // single-assign flow — reassigning the same driver skips the check).
+    if (driverId !== row.driver_id) {
+      driverStatus = await getDriverDayStatus(
+        supabase,
+        driverId,
+        row.date,
+        row.pickup_time
+      )
+    }
+    guardByRide.set(row.id, driverStatus)
+    legStates.push({
+      rideId: row.id,
+      role,
+      status: row.status,
+      currentDriverId: row.driver_id,
+      isAbsent: driverStatus?.isAbsent ?? false,
+    })
+  }
+
+  // 4) Atomic go/no-go. Aborts (nothing assigned) if any leg's driver is absent.
+  const plan = planCoAssignment(legStates, driverId)
+  if (!plan.proceed) {
+    return { success: false, error: plan.error }
+  }
+
+  // 5) Apply the DB updates. Collect enough to roll back if a later write fails.
+  const applied: Array<{
+    rideId: string
+    prevDriverId: string | null
+    prevStatus: Enums<"ride_status">
+  }> = []
+
+  for (const leg of plan.legs) {
+    const source = legRows.find((l) => l.row.id === leg.rideId)
+    if (!source) continue
+
+    const updateData: {
+      driver_id: string
+      status?: Enums<"ride_status">
+    } = { driver_id: driverId }
+    if (leg.statusChanged) updateData.status = leg.targetStatus
+
+    const { error } = await supabase
+      .from("rides")
+      .update(updateData)
+      .eq("id", leg.rideId)
+
+    if (error) {
+      // Roll back everything applied so far so the operation stays all-or-none.
+      await rollbackAppliedLegs(supabase, applied)
+      return {
+        success: false,
+        error: `Zuweisung fehlgeschlagen: ${error.message}`,
+      }
+    }
+
+    applied.push({
+      rideId: leg.rideId,
+      prevDriverId: source.row.driver_id,
+      prevStatus: source.row.status,
+    })
+  }
+
+  // 6) All writes succeeded — run per-leg side effects (audit, out-of-avail
+  //    note, token invalidation, acceptance tracking, request mail, events).
+  const acceptanceEnabled = isAcceptanceFlowEnabled()
+  const assignedRideIds: string[] = []
+
+  for (const leg of plan.legs) {
+    const source = legRows.find((l) => l.row.id === leg.rideId)
+    if (!source) continue
+    const row = source.row
+    assignedRideIds.push(leg.rideId)
+
+    // Manipulation-safe audit trail for every assignment (#181).
+    if (leg.driverChanged) {
+      logAudit({
+        userId: auth.userId,
+        userRole: auth.role,
+        action: "assign",
+        entityType: "ride",
+        entityId: leg.rideId,
+        changes: {
+          driver_id: { old: row.driver_id, new: driverId },
+          status: { old: row.status, new: leg.targetStatus },
+        },
+        metadata: { co_assign: true, leg: leg.role },
+      }).catch(() => {})
+    }
+
+    // Note out-of-availability assignment in the communication_log (#104).
+    const guard = guardByRide.get(leg.rideId)
+    if (guard && !guard.isWithinAvailability) {
+      await logOutsideAvailabilityAssignment(supabase, {
+        rideId: leg.rideId,
+        authorId: auth.userId,
+        pickupTime: row.pickup_time,
+        hasAvailability: guard.hasAvailability,
+      })
+    }
+
+    // A fresh acceptance request is needed for this leg.
+    if (leg.requestAcceptance) {
+      await invalidateTokensForRide(leg.rideId)
+
+      // Fire-and-forget: send this leg's driver request email (one per leg).
+      sendDriverNotification(leg.rideId, driverId).catch(console.error)
+
+      // Per-ride status history (#164): dispatcher requested this driver.
+      await recordAssignmentEvent({
+        rideId: leg.rideId,
+        driverId,
+        event: "requested",
+        actor: "dispatcher",
+        detail: leg.role === "return" ? "return_leg" : null,
+      })
+
+      if (acceptanceEnabled) {
+        await createAcceptanceTracking(
+          leg.rideId,
+          driverId,
+          row.date,
+          row.pickup_time
+        )
+      }
+    }
+  }
+
+  revalidatePath("/dispatch")
+  revalidatePath("/rides")
+  revalidatePath("/my/rides")
+
+  return {
+    success: true,
+    data: {
+      assignedRideIds,
+      returnLegAssigned: plan.legs.some((l) => l.role === "return"),
+      ...(skippedReason ? { returnLegSkippedReason: skippedReason } : {}),
+    },
+  }
+}
+
+/**
+ * Revert `driver_id`/`status` for legs already updated in a co-assignment when a
+ * later leg's write fails, keeping the operation all-or-none (#182). Best-effort:
+ * logs but never throws so the caller can still surface the original error.
+ */
+async function rollbackAppliedLegs(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  applied: Array<{
+    rideId: string
+    prevDriverId: string | null
+    prevStatus: Enums<"ride_status">
+  }>
+): Promise<void> {
+  for (const leg of applied) {
+    const { error } = await supabase
+      .from("rides")
+      .update({ driver_id: leg.prevDriverId, status: leg.prevStatus })
+      .eq("id", leg.rideId)
+    if (error) {
+      console.error(
+        `[co-assign] Rollback failed for ride ${leg.rideId}:`,
+        error.message
+      )
+    }
+  }
 }
 
 /**

--- a/src/lib/rides/__tests__/co-assign.test.ts
+++ b/src/lib/rides/__tests__/co-assign.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest"
+import {
+  resolveLinkedLegId,
+  isCoAssignable,
+  planCoAssignment,
+  CO_ASSIGN_PRIMARY_ABSENT_ERROR,
+  CO_ASSIGN_RETURN_ABSENT_ERROR,
+  type CoAssignLegState,
+} from "../co-assign"
+
+const OUTBOUND = "11111111-1111-4111-8111-111111111111"
+const RETURN = "22222222-2222-4222-8222-222222222222"
+const DRIVER = "99999999-9999-4999-8999-999999999999"
+
+describe("resolveLinkedLegId", () => {
+  it("returns the parent id when the primary is itself a return leg", () => {
+    expect(
+      resolveLinkedLegId({ id: RETURN, parent_ride_id: OUTBOUND }, null)
+    ).toBe(OUTBOUND)
+  })
+
+  it("returns the child id when the primary is an outbound leg", () => {
+    expect(
+      resolveLinkedLegId({ id: OUTBOUND, parent_ride_id: null }, RETURN)
+    ).toBe(RETURN)
+  })
+
+  it("prefers the parent link over a passed child id (return leg wins)", () => {
+    // A return leg should never also be a parent, but the parent link is
+    // authoritative regardless of what the caller passes as childId.
+    expect(
+      resolveLinkedLegId({ id: RETURN, parent_ride_id: OUTBOUND }, "other")
+    ).toBe(OUTBOUND)
+  })
+
+  it("returns null for a single-leg ride with no link in either direction", () => {
+    expect(
+      resolveLinkedLegId({ id: OUTBOUND, parent_ride_id: null }, null)
+    ).toBeNull()
+  })
+})
+
+describe("isCoAssignable", () => {
+  it("allows unplanned, planned and rejected legs", () => {
+    expect(isCoAssignable("unplanned")).toBe(true)
+    expect(isCoAssignable("planned")).toBe(true)
+    expect(isCoAssignable("rejected")).toBe(true)
+  })
+
+  it("rejects terminal and in-progress legs", () => {
+    expect(isCoAssignable("confirmed")).toBe(false)
+    expect(isCoAssignable("in_progress")).toBe(false)
+    expect(isCoAssignable("picked_up")).toBe(false)
+    expect(isCoAssignable("arrived")).toBe(false)
+    expect(isCoAssignable("completed")).toBe(false)
+    expect(isCoAssignable("cancelled")).toBe(false)
+    expect(isCoAssignable("no_show")).toBe(false)
+  })
+})
+
+describe("planCoAssignment", () => {
+  const primaryUnplanned: CoAssignLegState = {
+    rideId: OUTBOUND,
+    role: "primary",
+    status: "unplanned",
+    currentDriverId: null,
+    isAbsent: false,
+  }
+  const returnUnplanned: CoAssignLegState = {
+    rideId: RETURN,
+    role: "return",
+    status: "unplanned",
+    currentDriverId: null,
+    isAbsent: false,
+  }
+
+  it("co-assigns both legs: both transition unplanned -> planned and request acceptance", () => {
+    const plan = planCoAssignment(
+      [primaryUnplanned, returnUnplanned],
+      DRIVER
+    )
+
+    expect(plan.proceed).toBe(true)
+    if (!plan.proceed) return
+    expect(plan.legs).toHaveLength(2)
+    for (const leg of plan.legs) {
+      expect(leg.targetStatus).toBe("planned")
+      expect(leg.statusChanged).toBe(true)
+      expect(leg.driverChanged).toBe(true)
+      expect(leg.requestAcceptance).toBe(true)
+    }
+  })
+
+  it("aborts the whole plan when the driver is absent for the PRIMARY leg", () => {
+    const plan = planCoAssignment(
+      [{ ...primaryUnplanned, isAbsent: true }, returnUnplanned],
+      DRIVER
+    )
+    expect(plan).toEqual({
+      proceed: false,
+      error: CO_ASSIGN_PRIMARY_ABSENT_ERROR,
+    })
+  })
+
+  it("aborts the whole plan when the driver is absent for the RETURN leg (nothing assigned)", () => {
+    const plan = planCoAssignment(
+      [primaryUnplanned, { ...returnUnplanned, isAbsent: true }],
+      DRIVER
+    )
+    expect(plan).toEqual({
+      proceed: false,
+      error: CO_ASSIGN_RETURN_ABSENT_ERROR,
+    })
+  })
+
+  it("plans a single leg when there is no linked leg", () => {
+    const plan = planCoAssignment([primaryUnplanned], DRIVER)
+    expect(plan.proceed).toBe(true)
+    if (!plan.proceed) return
+    expect(plan.legs).toHaveLength(1)
+    expect(plan.legs[0]?.rideId).toBe(OUTBOUND)
+    expect(plan.legs[0]?.requestAcceptance).toBe(true)
+  })
+
+  it("does not re-request acceptance when the same driver is reassigned", () => {
+    const plan = planCoAssignment(
+      [
+        {
+          rideId: OUTBOUND,
+          role: "primary",
+          status: "planned",
+          currentDriverId: DRIVER,
+          isAbsent: false,
+        },
+      ],
+      DRIVER
+    )
+    expect(plan.proceed).toBe(true)
+    if (!plan.proceed) return
+    expect(plan.legs[0]?.driverChanged).toBe(false)
+    expect(plan.legs[0]?.statusChanged).toBe(false)
+    expect(plan.legs[0]?.requestAcceptance).toBe(false)
+  })
+
+  it("keeps a rejected leg's status but re-requests acceptance for a new driver", () => {
+    // A rejected leg stays `rejected` here (no unplanned auto-transition), so it
+    // does not trigger a fresh request — the caller decides how to handle a
+    // rejected linked leg. Guard against accidental status promotion.
+    const plan = planCoAssignment(
+      [
+        {
+          rideId: OUTBOUND,
+          role: "primary",
+          status: "rejected",
+          currentDriverId: null,
+          isAbsent: false,
+        },
+      ],
+      DRIVER
+    )
+    expect(plan.proceed).toBe(true)
+    if (!plan.proceed) return
+    expect(plan.legs[0]?.targetStatus).toBe("rejected")
+    expect(plan.legs[0]?.statusChanged).toBe(false)
+    expect(plan.legs[0]?.driverChanged).toBe(true)
+    expect(plan.legs[0]?.requestAcceptance).toBe(false)
+  })
+})

--- a/src/lib/rides/co-assign.ts
+++ b/src/lib/rides/co-assign.ts
@@ -1,0 +1,161 @@
+/**
+ * Co-assignment planning for linked ride legs (Issue #167, M15).
+ *
+ * When a dispatcher assigns a driver to a ride, they may want the *same* driver
+ * to take the linked return leg in one action (concept §2.1/§2.3). The link
+ * already exists as `rides.parent_ride_id` (self-FK, return leg → outbound leg)
+ * — no new column is needed (EPIC #175).
+ *
+ * This module holds the **pure** decision logic so it can be unit-tested without
+ * a database:
+ *   - `resolveLinkedLegId`  — which ride is the linked leg (bidirectional).
+ *   - `isCoAssignable`      — may a leg receive a co-assignment at all.
+ *   - `planCoAssignment`    — atomic go/no-go plan for all legs together.
+ *
+ * The security-relevant rule (#182) is enforced here: the conflict/absence guard
+ * covers *every* leg, and if any leg fails hard the whole plan is rejected
+ * (nothing is assigned). The IO orchestration lives in `src/actions/rides.ts`.
+ */
+
+import type { Enums } from "@/lib/types/database"
+
+type RideStatus = Enums<"ride_status">
+
+/** Which of the two legs a planned entry refers to (for UI feedback + errors). */
+export type LegRole = "primary" | "return"
+
+/**
+ * Statuses in which a leg may still receive a driver co-assignment.
+ *
+ * Terminal legs (`completed`, `cancelled`, `no_show`) and legs already in the
+ * ride (`in_progress`, `picked_up`, `arrived`) must never be clobbered by a
+ * co-assignment — the linked return leg is silently skipped in those cases, the
+ * primary action still succeeds for the leg the dispatcher explicitly picked.
+ */
+const CO_ASSIGNABLE_STATUSES: ReadonlySet<RideStatus> = new Set<RideStatus>([
+  "unplanned",
+  "planned",
+  "rejected",
+])
+
+/** Shown when the driver is on an approved absence at the outbound leg's time. */
+export const CO_ASSIGN_PRIMARY_ABSENT_ERROR =
+  "Der gewaehlte Fahrer ist an diesem Datum abwesend (Ferien/Abwesenheit). Bitte einen anderen Fahrer waehlen."
+
+/**
+ * Shown when the driver is absent at the *return* leg's time. Because the two
+ * legs are assigned atomically (#182), nothing is assigned in this case and the
+ * dispatcher is told explicitly so they can pick another driver or dispatch the
+ * return leg separately.
+ */
+export const CO_ASSIGN_RETURN_ABSENT_ERROR =
+  "Der gewaehlte Fahrer ist zum Zeitpunkt der Rueckfahrt abwesend (Ferien/Abwesenheit). Es wurde keine Fahrt zugewiesen. Bitte einen anderen Fahrer waehlen oder die Rueckfahrt separat disponieren."
+
+/**
+ * Determine whether a leg may receive a co-assignment.
+ */
+export function isCoAssignable(status: RideStatus): boolean {
+  return CO_ASSIGNABLE_STATUSES.has(status)
+}
+
+/**
+ * Resolve the id of the leg linked to `primary` via `parent_ride_id`, in both
+ * directions (concept §2.1, issue #167):
+ *
+ *   - If `primary` is itself a return leg (`parent_ride_id` set), the linked leg
+ *     is its parent (the outbound leg).
+ *   - Otherwise `primary` is an outbound leg and the linked leg is the return
+ *     leg whose `parent_ride_id` points back at it (`childId`, looked up by the
+ *     caller).
+ *
+ * Returns `null` when there is no linked leg (single-leg ride).
+ */
+export function resolveLinkedLegId(
+  primary: { id: string; parent_ride_id: string | null },
+  childId: string | null
+): string | null {
+  if (primary.parent_ride_id) return primary.parent_ride_id
+  return childId
+}
+
+/** Input state for one leg going into the co-assignment plan. */
+export interface CoAssignLegState {
+  rideId: string
+  role: LegRole
+  status: RideStatus
+  currentDriverId: string | null
+  /** From `getDriverDayStatus`: driver is on an approved absence that day/time. */
+  isAbsent: boolean
+}
+
+/** A single leg's resolved assignment action. */
+export interface PlannedLeg {
+  rideId: string
+  role: LegRole
+  targetStatus: RideStatus
+  statusChanged: boolean
+  driverChanged: boolean
+  /**
+   * Whether this leg needs a fresh acceptance request (tracking + mail + event):
+   * true when a (new) driver is assigned and the leg ends up `planned`.
+   */
+  requestAcceptance: boolean
+}
+
+export type CoAssignPlan =
+  | { proceed: false; error: string }
+  | { proceed: true; legs: PlannedLeg[] }
+
+/**
+ * Build the atomic co-assignment plan for one or two legs.
+ *
+ * Security rule (#182): if the driver is absent for *any* leg, the whole plan is
+ * rejected and nothing is assigned. Only when every leg passes the guard is a
+ * `proceed: true` plan returned, so the caller can apply the DB updates.
+ *
+ * `newDriverId` must be non-null — this action only assigns drivers; removal
+ * goes through `assignDriver`.
+ */
+export function planCoAssignment(
+  legs: CoAssignLegState[],
+  newDriverId: string
+): CoAssignPlan {
+  // Hard guard first (before deciding any transition): a single absent leg
+  // aborts the entire operation. The primary leg's message matches the existing
+  // single-assign flow; the return leg gets a dedicated message.
+  for (const leg of legs) {
+    if (leg.isAbsent) {
+      return {
+        proceed: false,
+        error:
+          leg.role === "primary"
+            ? CO_ASSIGN_PRIMARY_ABSENT_ERROR
+            : CO_ASSIGN_RETURN_ABSENT_ERROR,
+      }
+    }
+  }
+
+  const planned: PlannedLeg[] = legs.map((leg) => {
+    // Mirror the single-assign auto-transition: an unplanned leg with no driver
+    // becomes `planned` when a driver is set. Any other status is preserved.
+    const targetStatus: RideStatus =
+      leg.status === "unplanned" && !leg.currentDriverId
+        ? "planned"
+        : leg.status
+
+    const driverChanged = newDriverId !== leg.currentDriverId
+
+    return {
+      rideId: leg.rideId,
+      role: leg.role,
+      targetStatus,
+      statusChanged: targetStatus !== leg.status,
+      driverChanged,
+      // A fresh request is needed when we newly (re)assign the driver and the
+      // leg is in the `planned` state awaiting acceptance.
+      requestAcceptance: driverChanged && targetStatus === "planned",
+    }
+  })
+
+  return { proceed: true, legs: planned }
+}


### PR DESCRIPTION
## Was & Warum

Teil von **M15 – Fahrer-Zuweisung & Workflow**, Phase 15.1. Damit derselbe Fahrer Hin- und Rückfahrt übernehmen kann, kann die Zuweisung jetzt beide Legs in **einer Aktion** anfragen. Die Verknüpfung nutzt das bestehende `rides.parent_ride_id` (Self-FK, Rückfahrt → Hinfahrt) — kein neues Feld, kein neues Table, keine Migration (EPIC #175).

## Umgesetzt

- **Neue Server-Action** `assignDriverWithReturn(rideId, driverId, { includeReturn })` in `src/actions/rides.ts`.
  - Ermittelt das verknüpfte Leg über `parent_ride_id` **bidirektional** (von der Hinfahrt zum Kind, von der Rückfahrt zum Parent).
  - Weist bei `includeReturn` beiden Fahrten denselben Fahrer zu und erzeugt für **beide** je ein `acceptance_tracking`, je ein `assignment_events`-`requested` und je eine Anfrage-Mail.
  - Rückgabe (`AssignWithReturnResult`) meldet, welche Legs zugewiesen wurden (`assignedRideIds`, `returnLegAssigned`, `returnLegSkippedReason`) — für UI-Feedback in Phase 15.2.
  - `revalidatePath('/dispatch' | '/rides' | '/my/rides')`.
- **Pure Planungslogik** in `src/lib/rides/co-assign.ts` (`resolveLinkedLegId`, `isCoAssignable`, `planCoAssignment`) — DB-frei und voll unit-getestet.

## Security #182 — Konfliktprüfung über beide Legs

Der Absenz-/Verfügbarkeits-Guard (`getDriverDayStatus`) läuft für **jedes** Leg **bevor** irgendetwas geschrieben wird. Ist der Fahrer für **irgendein** Leg abwesend, wird **nichts** zugewiesen und ein sprechender Fehler zurückgegeben (getrennte Meldung für Hin- vs. Rückfahrt). Schlägt ein späterer DB-Write fehl, werden bereits angewandte Legs zurückgerollt (all-or-none). Out-of-Availability wird — wie im bestehenden Flow — pro Leg im `communication_log` notiert, blockiert aber nicht. Jede Zuweisung schreibt einen `audit_log`-Eintrag (`co_assign`-Metadaten pro Leg).

## Entscheidungen

- **Mail-Variante (dokumentiert):** MVP = zwei separate Anfrage-Mails (ein Token pro Leg). Das ist am robustesten; eine echte Ein-Mail-mit-Doppel-Token-Zusage ist Nice-to-have und gehört in ein Folge-Issue.
- **`assignDriver` bleibt unangetastet** (Removal-Pfad, Einzel-Zuweisung über die Dispatch-Karte) — die neue Action deckt ausschliesslich den Zuweisungs-Fall ab. So kein Regressionsrisiko am bestehenden Pfad.
- **Verknüpftes Leg in terminalem/laufendem Status** (`completed`/`cancelled`/`in_progress`/…) wird **nicht** überschrieben — es wird übersprungen (`returnLegSkippedReason: "not_assignable"`), die primäre Zuweisung gelingt trotzdem.

## Tests

- `src/lib/rides/__tests__/co-assign.test.ts` — 12 Tests: bidirektionale Leg-Auflösung, Co-Assign beider Legs, Guard-Abbruch (Hin- **und** Rückfahrt), Einzel-Leg, Reassign-desselben-Fahrers.
- `src/actions/__tests__/assign-driver-with-return.test.ts` — 8 Tests: Orchestrierung (beide Legs, bidirektional, Guard-Ablehnung schreibt nichts, kein verknüpftes Leg, nicht-zuweisbares Leg, `includeReturn=false`, Rollback, Auth).
- Voller `vitest run`: **1088 Tests grün** (71 Dateien). Typecheck (`tsc --noEmit`) grün. Lint: nur vorbestehende Warnungen, keine in den neuen Dateien.

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)
