### PR TITLE
feat(m15): Split-View /dispatch — Fahrten links, Fahrer rechts, Status-Tabs, Wochen-Navigation (Grundgerüst)

### DIFF
--- a/src/app/(dashboard)/dispatch/page.tsx
+++ b/src/app/(dashboard)/dispatch/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import Link from "next/link"
 import { redirect } from "next/navigation"
 import { createClient } from "@/lib/supabase/server"
 import { requireAuth } from "@/lib/auth/require-auth"
@@ -9,8 +10,13 @@ import {
   type DispatchDriver,
   type DriverAvailabilityMap,
 } from "@/components/dispatch/dispatch-board"
-import { DispatchWeekView } from "@/components/dispatch/dispatch-week-view"
+import { SplitView } from "@/components/dispatch/split-view"
+import type {
+  SplitRide,
+  SplitDriver,
+} from "@/components/dispatch/split-view-types"
 import { WeekNav } from "@/components/shared/week-nav"
+import { Button } from "@/components/ui/button"
 import { type QueueEntry } from "@/components/acceptance/acceptance-queue"
 import { AcceptanceQueueWrapper } from "@/components/acceptance/acceptance-queue-wrapper"
 import {
@@ -18,7 +24,17 @@ import {
   ACTIVE_STAGES,
 } from "@/lib/acceptance/constants"
 import { checkPendingAcceptances } from "@/lib/acceptance/engine"
-import { getToday, getMondayOf, getSundayOf, getWeekDates } from "@/lib/utils/dates"
+import { getToday, getMondayOf, getSundayOf } from "@/lib/utils/dates"
+import {
+  deriveAssignmentStatus,
+  deriveAngefragtTiming,
+  ASSIGNMENT_RIDE_STATUSES,
+} from "@/lib/dispatch/assignment-status"
+import { loadDriverSchedules } from "@/lib/availability/assignment"
+import {
+  resolveDriverDayStatus,
+  findAbsenceOn,
+} from "@/lib/availability/driver-status"
 import type { AcceptanceStage } from "@/lib/acceptance/types"
 import { PrintDayButton } from "@/components/dispatch/print-day-button"
 import { NewRideButton } from "@/components/rides/new-ride-button"
@@ -44,6 +60,7 @@ interface DispatchPageProps {
 }
 
 export default async function DispatchPage({ searchParams }: DispatchPageProps) {
+  // #180: gate server-side. Drivers never reach a data render — redirect first.
   const auth = await requireAuth(["admin", "operator"])
   if (!auth.authorized) {
     redirect("/login")
@@ -52,71 +69,229 @@ export default async function DispatchPage({ searchParams }: DispatchPageProps) 
   const { date, week } = await searchParams
   const today = getToday()
 
-  // --- DAY VIEW (default: today, or specific ?date= param) ---
-  if (!week) {
-    const selectedDate = date ?? today
-    return renderDayView(selectedDate, today)
+  // Day view stays reachable via ?date= (existing DispatchBoard, unchanged).
+  if (date) {
+    return renderDayView(date, today)
   }
 
-  // --- WEEK VIEW (only when ?week= param is present) ---
-  const weekStart = getMondayOf(week)
+  // Default experience: weekly split-view (Fahrten links, Fahrer rechts).
+  const weekStart = week ? getMondayOf(week) : getMondayOf(today)
+  return renderSplitView(weekStart, today)
+}
+
+// ---------------------------------------------------------------------------
+// Split-View (M15, #168) — weekly assignment surface
+// ---------------------------------------------------------------------------
+
+async function renderSplitView(weekStart: string, today: string) {
   const weekEnd = getSundayOf(weekStart)
   const todayWeekStart = getMondayOf(today)
-  const weekDates = getWeekDates(weekStart)
-
   const supabase = await createClient()
 
-  const { data: weekRides } = await supabase
-    .from("rides")
-    .select(
-      "id, date, pickup_time, status, driver_id, patients(first_name, last_name), drivers(last_name)"
+  // 1) Rides for the week + active drivers, in parallel. Rides are scoped to the
+  //    four assignment-relevant statuses (concept §0) so terminal / in-transport
+  //    rides never load.
+  const [ridesResult, driversResult] = await Promise.all([
+    supabase
+      .from("rides")
+      .select(
+        "id, date, pickup_time, status, direction, driver_id, parent_ride_id, requirements, patients(first_name, last_name, city), destinations(display_name)"
+      )
+      .gte("date", weekStart)
+      .lte("date", weekEnd)
+      .eq("is_active", true)
+      .in("status", [...ASSIGNMENT_RIDE_STATUSES])
+      .order("date")
+      .order("pickup_time"),
+
+    supabase
+      .from("drivers")
+      .select("id, first_name, last_name, vehicle_type")
+      .eq("is_active", true)
+      .order("last_name"),
+  ])
+
+  const rawRides = ridesResult.data ?? []
+  const rawDrivers = driversResult.data ?? []
+  const rideIds = rawRides.map((r) => r.id)
+  const driverIds = rawDrivers.map((d) => d.id)
+
+  // 2) Bundled follow-ups — all keyed by the IDs from step 1 (no N+1).
+  const [schedules, trackingResult, rejectionResult] = await Promise.all([
+    loadDriverSchedules(supabase, driverIds, today),
+
+    rideIds.length > 0
+      ? supabase
+          .from("acceptance_tracking")
+          .select("ride_id, stage, is_short_notice, notified_at")
+          .in("ride_id", rideIds)
+          .in("stage", [...ACTIVE_STAGES, "timed_out"])
+      : Promise.resolve({
+          data: [] as {
+            ride_id: string
+            stage: AcceptanceStage
+            is_short_notice: boolean
+            notified_at: string
+          }[],
+        }),
+
+    // Latest decline per ride, for the Abgelehnt cards (assignment_events, #164).
+    rideIds.length > 0
+      ? supabase
+          .from("assignment_events")
+          .select("ride_id, driver_id, created_at")
+          .eq("event", "rejected")
+          .in("ride_id", rideIds)
+          .order("created_at", { ascending: false })
+      : Promise.resolve({
+          data: [] as {
+            ride_id: string
+            driver_id: string | null
+            created_at: string
+          }[],
+        }),
+  ])
+
+  // --- Lookup maps ---
+
+  /** driverId -> "V. Nachname" (compact, as in the concept mockup). */
+  const driverNameById = new Map<string, string>()
+  for (const d of rawDrivers) {
+    driverNameById.set(
+      d.id,
+      `${d.first_name.charAt(0)}. ${d.last_name}`.trim()
     )
-    .gte("date", weekStart)
-    .lte("date", weekEnd)
-    .eq("is_active", true)
-    .order("date")
-    .order("pickup_time")
-
-  // Group rides by date
-  type DispatchWeekRide = {
-    id: string
-    date: string
-    pickup_time: string
-    status: Enums<"ride_status">
-    driver_id: string | null
-    driver_last_name: string | null
-    patient_last_name: string
-    patient_first_name: string
   }
 
-  const ridesByDate = new Map<string, DispatchWeekRide[]>()
-  for (const ride of weekRides ?? []) {
-    const patient = ride.patients as { first_name: string; last_name: string } | null
-    const driver = ride.drivers as { last_name: string } | null
-    const mapped: DispatchWeekRide = {
-      id: ride.id,
-      date: ride.date,
-      pickup_time: ride.pickup_time,
-      status: ride.status,
-      driver_id: ride.driver_id,
-      driver_last_name: driver?.last_name ?? null,
-      patient_last_name: patient?.last_name ?? "\u2013",
-      patient_first_name: patient?.first_name ?? "\u2013",
+  /** parentRideId -> linked return ride pickup time. */
+  const returnByParentId = new Map<string, string>()
+  for (const r of rawRides) {
+    if (r.parent_ride_id) {
+      returnByParentId.set(r.parent_ride_id, r.pickup_time)
     }
-    const existing = ridesByDate.get(ride.date) ?? []
-    existing.push(mapped)
-    ridesByDate.set(ride.date, existing)
   }
+
+  /** rideId -> active acceptance tracking (for the overdue marker). */
+  const trackingByRideId = new Map<
+    string,
+    { stage: AcceptanceStage; is_short_notice: boolean; notified_at: string }
+  >()
+  for (const t of trackingResult.data ?? []) {
+    if (!trackingByRideId.has(t.ride_id)) {
+      trackingByRideId.set(t.ride_id, {
+        stage: t.stage,
+        is_short_notice: t.is_short_notice,
+        notified_at: t.notified_at,
+      })
+    }
+  }
+
+  /** rideId -> latest decline (driver + time). Events are desc-ordered. */
+  const rejectionByRideId = new Map<
+    string,
+    { driver_id: string | null; created_at: string }
+  >()
+  for (const ev of rejectionResult.data ?? []) {
+    if (!rejectionByRideId.has(ev.ride_id)) {
+      rejectionByRideId.set(ev.ride_id, {
+        driver_id: ev.driver_id,
+        created_at: ev.created_at,
+      })
+    }
+  }
+
+  const now = new Date()
+
+  // --- Build SplitRide[] ---
+  const rides: SplitRide[] = []
+  for (const r of rawRides) {
+    const assignmentStatus = deriveAssignmentStatus(r.status)
+    if (!assignmentStatus) continue // out-of-scope status (defensive; query filters)
+
+    const patient = r.patients as {
+      first_name: string
+      last_name: string
+      city: string | null
+    } | null
+    const destination = r.destinations as { display_name: string } | null
+
+    const tracking = trackingByRideId.get(r.id) ?? null
+    const overdue =
+      assignmentStatus === "angefragt"
+        ? deriveAngefragtTiming(tracking, now).overdue
+        : false
+
+    const rejection = rejectionByRideId.get(r.id)
+
+    rides.push({
+      id: r.id,
+      date: r.date,
+      pickup_time: r.pickup_time,
+      status: r.status,
+      assignmentStatus,
+      direction: r.direction,
+      patient_first_name: patient?.first_name ?? "–",
+      patient_last_name: patient?.last_name ?? "–",
+      patient_city: patient?.city ?? null,
+      destination_name: destination?.display_name ?? "–",
+      requirements: r.requirements ?? [],
+      parent_ride_id: r.parent_ride_id,
+      assigned_driver_name: r.driver_id
+        ? driverNameById.get(r.driver_id) ?? null
+        : null,
+      linked_return_time: returnByParentId.get(r.id) ?? null,
+      overdue,
+      rejected_by_name:
+        assignmentStatus === "abgelehnt" && rejection?.driver_id
+          ? driverNameById.get(rejection.driver_id) ?? null
+          : null,
+      rejected_at:
+        assignmentStatus === "abgelehnt" ? rejection?.created_at ?? null : null,
+    })
+  }
+
+  // --- Per-driver ride counts for the period (workload = requested + confirmed) ---
+  const periodRideCount = new Map<string, number>()
+  for (const r of rawRides) {
+    if (!r.driver_id) continue
+    const bucket = deriveAssignmentStatus(r.status)
+    if (bucket !== "angefragt" && bucket !== "bestaetigt") continue
+    periodRideCount.set(r.driver_id, (periodRideCount.get(r.driver_id) ?? 0) + 1)
+  }
+
+  // --- Build SplitDriver[] with today's neutral availability (#187) ---
+  const scheduleByDriverId = new Map(schedules.map((s) => [s.driverId, s]))
+  const drivers: SplitDriver[] = rawDrivers.map((d) => {
+    const schedule = scheduleByDriverId.get(d.id)
+    const availability = schedule?.availability ?? []
+    const absences = schedule?.absences ?? []
+    const status = resolveDriverDayStatus(today, null, availability, absences)
+    const coveringAbsence = findAbsenceOn(today, absences)
+
+    return {
+      id: d.id,
+      first_name: d.first_name,
+      last_name: d.last_name,
+      vehicle_type: d.vehicle_type,
+      today_slots: status.windows.map((w) => w.start.slice(0, 5)),
+      is_absent_today: status.isAbsent,
+      // Neutral: end date only, never the reason (#187).
+      absent_until: coveringAbsence?.end_date ?? null,
+      period_ride_count: periodRideCount.get(d.id) ?? 0,
+    }
+  })
 
   return (
     <div className="-mx-4 mx-auto max-w-none space-y-6 px-4 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
       <PageHeader
-        title="Disposition"
-        description="Wochenuebersicht"
+        title="Fahrer-Zuteilung"
+        description="Fahrten links, Fahrer rechts – Zuteilung pro Woche"
         actions={
           <>
-            <NewRideButton />
-            <PrintDayButton date={today} />
+            <NewRideButton defaultDate={today} />
+            <Button variant="outline" size="sm" asChild>
+              <Link href={`/dispatch?date=${today}`}>Tagesansicht</Link>
+            </Button>
           </>
         }
       />
@@ -127,16 +302,14 @@ export default async function DispatchPage({ searchParams }: DispatchPageProps) 
         todayWeekStart={todayWeekStart}
       />
 
-      <DispatchWeekView
-        weekDates={weekDates}
-        ridesByDate={ridesByDate}
-        today={today}
-      />
+      <SplitView rides={rides} drivers={drivers} />
     </div>
   )
 }
 
-// --- Day View (extracted for clarity) ---
+// ---------------------------------------------------------------------------
+// Day View (existing DispatchBoard — unchanged, reachable via ?date=)
+// ---------------------------------------------------------------------------
 
 async function renderDayView(selectedDate: string, today: string) {
   const selectedDateObj = new Date(selectedDate + "T00:00:00")
@@ -210,9 +383,9 @@ async function renderDayView(selectedDate: string, today: string) {
       appointment_time: ride.appointment_time,
       parent_ride_id: ride.parent_ride_id,
       duration_seconds: ride.duration_seconds,
-      patient_first_name: patient?.first_name ?? "\u2013",
-      patient_last_name: patient?.last_name ?? "\u2013",
-      destination_name: destination?.display_name ?? "\u2013",
+      patient_first_name: patient?.first_name ?? "–",
+      patient_last_name: patient?.last_name ?? "–",
+      destination_name: destination?.display_name ?? "–",
     }
   })
 

--- a/src/components/dispatch/assignment-status-badge.tsx
+++ b/src/components/dispatch/assignment-status-badge.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@/lib/utils"
+import {
+  ASSIGNMENT_STATUS_LABELS,
+  ASSIGNMENT_STATUS_COLORS,
+  ASSIGNMENT_STATUS_DOT_COLORS,
+  type AssignmentStatus,
+} from "@/lib/dispatch/assignment-status"
+
+interface AssignmentStatusBadgeProps {
+  status: AssignmentStatus
+  className?: string
+}
+
+/**
+ * Badge for the four split-view assignment buckets (M15, #168).
+ *
+ * Distinct from `RideStatusBadge` (which renders the full 10-value ride
+ * lifecycle). Always shows dot + text — never color alone (accessibility,
+ * concept §6).
+ */
+export function AssignmentStatusBadge({
+  status,
+  className,
+}: AssignmentStatusBadgeProps) {
+  return (
+    <span
+      role="status"
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium",
+        ASSIGNMENT_STATUS_COLORS[status],
+        className
+      )}
+    >
+      <span
+        className={cn(
+          "h-1.5 w-1.5 shrink-0 rounded-full",
+          ASSIGNMENT_STATUS_DOT_COLORS[status]
+        )}
+        aria-hidden="true"
+      />
+      {ASSIGNMENT_STATUS_LABELS[status]}
+    </span>
+  )
+}

--- a/src/components/dispatch/driver-card.tsx
+++ b/src/components/dispatch/driver-card.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import { Badge } from "@/components/ui/badge"
+import { VEHICLE_TYPE_LABELS } from "@/lib/rides/constants"
+import { formatDayLabel } from "@/lib/utils/dates"
+import type { SplitDriver } from "@/components/dispatch/split-view-types"
+
+interface DriverCardProps {
+  driver: SplitDriver
+}
+
+/**
+ * A single driver card in the split-view right column (M15, #168).
+ *
+ * Shows name, vehicle type, today's availability short-info and the ride count
+ * for the selected period. Display-only in the grundgerüst — the `[Zuweisen]`
+ * button, context grouping (Verfügbar/Konflikt/Nicht verfügbar) and drop-target
+ * behaviour arrive with #169/#170.
+ *
+ * #187: an absence renders as a NEUTRAL "Nicht verfügbar bis …" — the absence
+ * REASON (e.g. Krankheit) is never surfaced here.
+ */
+export function DriverCard({ driver }: DriverCardProps) {
+  const availableToday = !driver.is_absent_today && driver.today_slots.length > 0
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between rounded-md border px-3 py-2",
+        availableToday
+          ? "border-green-200 bg-green-50"
+          : "border-gray-200 bg-gray-50"
+      )}
+    >
+      <div className="flex flex-col">
+        <span className="text-sm font-medium">
+          {driver.last_name}, {driver.first_name}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {VEHICLE_TYPE_LABELS[driver.vehicle_type]}
+          {driver.is_absent_today ? (
+            <>
+              {" · "}
+              <span>
+                Nicht verfügbar
+                {driver.absent_until && (
+                  <> bis {formatDayLabel(driver.absent_until)}</>
+                )}
+              </span>
+            </>
+          ) : availableToday ? (
+            <> {"·"} Heute: {driver.today_slots.join(", ")}</>
+          ) : (
+            <> {"·"} Heute nicht verfügbar</>
+          )}
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Badge
+          variant={driver.period_ride_count > 0 ? "default" : "secondary"}
+          className="tabular-nums"
+          title="Fahrten diese Woche"
+        >
+          {driver.period_ride_count}
+        </Badge>
+        <span
+          className={cn(
+            "h-2.5 w-2.5 shrink-0 rounded-full",
+            availableToday ? "bg-green-500" : "bg-gray-300"
+          )}
+          title={availableToday ? "Heute verfügbar" : "Heute nicht verfügbar"}
+          aria-label={availableToday ? "Heute verfügbar" : "Heute nicht verfügbar"}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/dispatch/driver-column.tsx
+++ b/src/components/dispatch/driver-column.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { DriverCard } from "@/components/dispatch/driver-card"
+import { formatDayLabel } from "@/lib/utils/dates"
+import type {
+  SplitDriver,
+  SplitRide,
+} from "@/components/dispatch/split-view-types"
+
+interface DriverColumnProps {
+  drivers: SplitDriver[]
+  /**
+   * The currently activated ride, if any. In the grundgerüst this only drives a
+   * context header; the actual availability grouping/sorting + `[Zuweisen]`
+   * (Verfügbar/Konflikt/Nicht verfügbar) is Issue #169. Kept as a prop so #169
+   * can dock without touching the layout.
+   */
+  activeRide: SplitRide | null
+}
+
+/**
+ * Right column of the split-view: the driver panel (M15, #168).
+ *
+ * Without an active ride it shows a flat, alphabetical list of active drivers
+ * with today's availability. It is `sticky` on desktop so the driver context
+ * stays visible while the (potentially long) ride list scrolls (Kim §1).
+ */
+export function DriverColumn({ drivers, activeRide }: DriverColumnProps) {
+  return (
+    <Card className="lg:sticky lg:top-4">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">Fahrer</CardTitle>
+        {activeRide && (
+          <p className="text-xs text-muted-foreground">
+            Aktive Fahrt: {formatDayLabel(activeRide.date)}{" "}
+            {activeRide.pickup_time.slice(0, 5)} {"·"}{" "}
+            {activeRide.destination_name}
+          </p>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {drivers.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Keine aktiven Fahrer</p>
+        ) : (
+          drivers.map((driver) => (
+            <DriverCard key={driver.id} driver={driver} />
+          ))
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/dispatch/ride-card.tsx
+++ b/src/components/dispatch/ride-card.tsx
@@ -1,0 +1,171 @@
+"use client"
+
+import { CornerDownLeft, AlertTriangle } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Badge } from "@/components/ui/badge"
+import { AssignmentStatusBadge } from "@/components/dispatch/assignment-status-badge"
+import { ASSIGNMENT_STATUS_BORDER_COLORS } from "@/lib/dispatch/assignment-status"
+import {
+  RIDE_REQUIREMENT_LABELS,
+  RIDE_DIRECTION_LABELS,
+} from "@/lib/rides/constants"
+import { formatDayLabel } from "@/lib/utils/dates"
+import type { SplitRide } from "@/components/dispatch/split-view-types"
+
+/** "HH:MM:SS" | "HH:MM" -> "HH:MM". */
+function formatTime(time: string): string {
+  return time.slice(0, 5)
+}
+
+/** ISO timestamp -> "17.07. 16:40" (Europe/Zurich wall clock is fine here). */
+function formatEventTime(iso: string): string {
+  const d = new Date(iso)
+  const day = String(d.getDate()).padStart(2, "0")
+  const month = String(d.getMonth() + 1).padStart(2, "0")
+  const hh = String(d.getHours()).padStart(2, "0")
+  const mm = String(d.getMinutes()).padStart(2, "0")
+  return `${day}.${month}. ${hh}:${mm}`
+}
+
+/**
+ * Build the "Von → Nach" label from trip direction. The patient's home town is
+ * one end, the facility the other. Falls back gracefully when the city is
+ * missing (only operationally relevant location data is shown — #179).
+ */
+function tripLabel(ride: SplitRide): string {
+  const home = ride.patient_city?.trim() || "Zuhause"
+  const facility = ride.destination_name
+  switch (ride.direction) {
+    case "outbound":
+      return `${home} → ${facility}`
+    case "return":
+      return `${facility} → ${home}`
+    case "both":
+      return `${home} ⇄ ${facility}`
+    default:
+      return facility
+  }
+}
+
+interface RideCardProps {
+  ride: SplitRide
+  isSelected: boolean
+  onSelect: (rideId: string) => void
+  onOpenDetail: (rideId: string) => void
+}
+
+/**
+ * A single ride card in the split-view left column (M15, #168).
+ *
+ * Display + selection only. Clicking the card ACTIVATES the ride (the docking
+ * point for context-filtering the driver panel in #169). A dedicated "Details"
+ * button opens the existing `RideQuickSheet`. The `[Zuweisen]` button, drag
+ * handle and live countdown are intentionally out of scope here (#169/#170/#171).
+ */
+export function RideCard({
+  ride,
+  isSelected,
+  onSelect,
+  onOpenDetail,
+}: RideCardProps) {
+  const isReturn = ride.parent_ride_id !== null
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-pressed={isSelected}
+      onClick={() => onSelect(ride.id)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          onSelect(ride.id)
+        }
+      }}
+      className={cn(
+        "cursor-pointer rounded-lg border border-l-4 bg-card p-4 shadow-sm transition-colors hover:bg-muted/50",
+        ASSIGNMENT_STATUS_BORDER_COLORS[ride.assignmentStatus],
+        isSelected && "ring-2 ring-primary ring-offset-2"
+      )}
+    >
+      {/* Row 1: date + time · status badge (+ overdue marker) */}
+      <div className="flex items-start justify-between gap-2">
+        <span className="text-sm font-semibold tabular-nums">
+          {formatDayLabel(ride.date)} {"·"} {formatTime(ride.pickup_time)}
+        </span>
+        <div className="flex items-center gap-1.5">
+          {ride.assignmentStatus === "angefragt" && ride.overdue && (
+            <Badge
+              variant="outline"
+              className="border-red-300 bg-red-50 text-red-700"
+            >
+              <AlertTriangle className="mr-1 h-3 w-3" aria-hidden="true" />
+              Überfällig
+            </Badge>
+          )}
+          {isReturn && (
+            <Badge variant="outline" className="text-xs">
+              Rückfahrt
+            </Badge>
+          )}
+          <AssignmentStatusBadge status={ride.assignmentStatus} />
+        </div>
+      </div>
+
+      {/* Row 2: Von → Nach */}
+      <p className="mt-1.5 text-sm font-medium">{tripLabel(ride)}</p>
+
+      {/* Row 3: patient + requirements (staff view — operational data only, #179) */}
+      <p className="mt-0.5 text-xs text-muted-foreground">
+        {ride.patient_last_name}, {ride.patient_first_name}
+        {ride.requirements.length > 0 && (
+          <>
+            {" · "}
+            {ride.requirements
+              .map((r) => RIDE_REQUIREMENT_LABELS[r])
+              .join(", ")}
+          </>
+        )}
+        {" · "}
+        {RIDE_DIRECTION_LABELS[ride.direction]}
+      </p>
+
+      {/* Row 4: linked return reference */}
+      {ride.linked_return_time && (
+        <p className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+          <CornerDownLeft className="h-3 w-3" aria-hidden="true" />
+          Rückfahrt {formatTime(ride.linked_return_time)} Uhr
+        </p>
+      )}
+
+      {/* Row 5a: requested driver (Angefragt) */}
+      {ride.assignmentStatus === "angefragt" && ride.assigned_driver_name && (
+        <p className="mt-1 text-xs text-amber-700">
+          → angefragt: {ride.assigned_driver_name}
+        </p>
+      )}
+
+      {/* Row 5b: rejection note (Abgelehnt) */}
+      {ride.assignmentStatus === "abgelehnt" && ride.rejected_by_name && (
+        <p className="mt-1 text-xs text-rose-700">
+          ⛔ Abgelehnt von {ride.rejected_by_name}
+          {ride.rejected_at && <> {"·"} {formatEventTime(ride.rejected_at)}</>}
+        </p>
+      )}
+
+      {/* Row 6: detail affordance (RideQuickSheet stays the detail surface) */}
+      <div className="mt-2 flex justify-end">
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            onOpenDetail(ride.id)
+          }}
+          className="rounded px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          Details
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/dispatch/ride-column.tsx
+++ b/src/components/dispatch/ride-column.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import { useMemo } from "react"
+import { cn } from "@/lib/utils"
+import { RideCard } from "@/components/dispatch/ride-card"
+import {
+  ASSIGNMENT_STATUS_ORDER,
+  ASSIGNMENT_STATUS_LABELS,
+  ASSIGNMENT_STATUS_TAB_ACTIVE_COLORS,
+  type AssignmentStatus,
+} from "@/lib/dispatch/assignment-status"
+import type { SplitRide } from "@/components/dispatch/split-view-types"
+
+interface RideColumnProps {
+  rides: SplitRide[]
+  activeTab: AssignmentStatus
+  onTabChange: (tab: AssignmentStatus) => void
+  selectedRideId: string | null
+  onSelectRide: (rideId: string) => void
+  onOpenDetail: (rideId: string) => void
+}
+
+/**
+ * Left column of the split-view: status tabs with counters + the filtered ride
+ * list (M15, #168).
+ *
+ * Exactly four buckets (concept §0). The "Abgelehnt" tab is only rendered when
+ * its count > 0 (reduces noise on quiet days, Kim §2); the other three are
+ * always visible even at 0. No "Alle" tab — the four buckets are complete and
+ * non-overlapping for the assignment question.
+ */
+export function RideColumn({
+  rides,
+  activeTab,
+  onTabChange,
+  selectedRideId,
+  onSelectRide,
+  onOpenDetail,
+}: RideColumnProps) {
+  const counts = useMemo(() => {
+    const c: Record<AssignmentStatus, number> = {
+      offen: 0,
+      angefragt: 0,
+      bestaetigt: 0,
+      abgelehnt: 0,
+    }
+    for (const ride of rides) c[ride.assignmentStatus]++
+    return c
+  }, [rides])
+
+  const visibleRides = useMemo(
+    () => rides.filter((r) => r.assignmentStatus === activeTab),
+    [rides, activeTab]
+  )
+
+  return (
+    <div className="space-y-4">
+      {/* Status tabs */}
+      <div
+        role="tablist"
+        aria-label="Fahrten nach Zuteilungsstatus"
+        className="flex flex-wrap gap-2"
+      >
+        {ASSIGNMENT_STATUS_ORDER.map((status) => {
+          const count = counts[status]
+          // Abgelehnt only appears when there is something to show.
+          if (status === "abgelehnt" && count === 0) return null
+          const isActive = activeTab === status
+          return (
+            <button
+              key={status}
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => onTabChange(status)}
+              className={cn(
+                "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                isActive
+                  ? ASSIGNMENT_STATUS_TAB_ACTIVE_COLORS[status]
+                  : "bg-muted text-muted-foreground hover:bg-muted/80"
+              )}
+            >
+              {ASSIGNMENT_STATUS_LABELS[status]}{" "}
+              <span className="tabular-nums">{count}</span>
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Ride list */}
+      {visibleRides.length === 0 ? (
+        <div className="flex min-h-[160px] items-center justify-center rounded-lg border border-dashed">
+          <p className="text-sm text-muted-foreground">
+            Keine Fahrten mit Status „{ASSIGNMENT_STATUS_LABELS[activeTab]}“
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {visibleRides.map((ride) => (
+            <RideCard
+              key={ride.id}
+              ride={ride}
+              isSelected={selectedRideId === ride.id}
+              onSelect={onSelectRide}
+              onOpenDetail={onOpenDetail}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/dispatch/split-view-types.ts
+++ b/src/components/dispatch/split-view-types.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared, serializable data shapes for the /dispatch split-view (M15, #168).
+ *
+ * These are the props the server page (`dispatch/page.tsx`) computes and passes
+ * down into the client split-view. Kept in a plain module (no "use client") so
+ * both the server loader and the client components can import them without
+ * pulling a component boundary across the server/client line.
+ */
+
+import type { Enums } from "@/lib/types/database"
+import type { AssignmentStatus } from "@/lib/dispatch/assignment-status"
+
+type RideStatus = Enums<"ride_status">
+type RideDirection = Enums<"ride_direction">
+type RideRequirement = Enums<"ride_requirement">
+type VehicleType = Enums<"vehicle_type">
+
+/** One ride card in the left column. */
+export interface SplitRide {
+  id: string
+  date: string
+  /** "HH:MM:SS" or "HH:MM". */
+  pickup_time: string
+  status: RideStatus
+  /** Pre-derived on the server (§0). Only rides with a non-null bucket load. */
+  assignmentStatus: AssignmentStatus
+  direction: RideDirection
+  patient_first_name: string
+  patient_last_name: string
+  /** Patient home town — the "Von" end of an outbound trip. May be null. */
+  patient_city: string | null
+  destination_name: string
+  /** Operationally relevant transport requirements (wheelchair, companion, …). */
+  requirements: RideRequirement[]
+  parent_ride_id: string | null
+  /** Currently requested driver, shown on Angefragt cards ("→ angefragt: …"). */
+  assigned_driver_name: string | null
+  /** Pickup time of the linked return ride, if any ("↩ Rückfahrt 11:00"). */
+  linked_return_time: string | null
+  /**
+   * Whether the acceptance request is past its next SLA deadline. Static
+   * server snapshot — the live countdown is Issue #171.
+   */
+  overdue: boolean
+  /** Driver who declined (Abgelehnt cards). */
+  rejected_by_name: string | null
+  /** When the decline happened (ISO). */
+  rejected_at: string | null
+}
+
+/** One driver card in the right column. */
+export interface SplitDriver {
+  id: string
+  first_name: string
+  last_name: string
+  vehicle_type: VehicleType
+  /**
+   * Today's availability slot starts ("08:00", "10:00", …). Empty when the
+   * driver has no window today.
+   */
+  today_slots: string[]
+  /**
+   * Whether the driver is on an approved absence today. The REASON is never
+   * exposed here (#187) — the UI shows a neutral "Nicht verfügbar" only.
+   */
+  is_absent_today: boolean
+  /**
+   * Neutral end date of the covering absence ("Nicht verfügbar bis …"), if
+   * absent today. Never the reason.
+   */
+  absent_until: string | null
+  /** Number of rides assigned to this driver in the selected period (week). */
+  period_ride_count: number
+}

--- a/src/components/dispatch/split-view.tsx
+++ b/src/components/dispatch/split-view.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { useCallback, useMemo, useState } from "react"
+import { RideColumn } from "@/components/dispatch/ride-column"
+import { DriverColumn } from "@/components/dispatch/driver-column"
+import { RideQuickSheet } from "@/components/rides/ride-quick-sheet"
+import { ASSIGNMENT_STATUS_ORDER, type AssignmentStatus } from "@/lib/dispatch/assignment-status"
+import type {
+  SplitRide,
+  SplitDriver,
+} from "@/components/dispatch/split-view-types"
+
+interface SplitViewProps {
+  rides: SplitRide[]
+  drivers: SplitDriver[]
+}
+
+/**
+ * Split-view orchestrator (M15, #168): Fahrten links, Fahrer rechts.
+ *
+ * Owns the two pieces of client state the grundgerüst needs:
+ *   - `activeTab`     — which of the four assignment buckets is shown.
+ *   - `selectedRideId`— the "activated" ride. This is the docking point for the
+ *     context-filtering + assign flow (#169): the driver panel already receives
+ *     the active ride, it just doesn't filter/sort by it yet.
+ *
+ * A separate `detailRideId` drives the existing `RideQuickSheet` (ride detail).
+ * Assign button, drag & drop and the live countdown are deliberately absent
+ * here — they land in #169/#170/#171.
+ */
+export function SplitView({ rides, drivers }: SplitViewProps) {
+  // Default to the first tab (in order) that actually has rides, else "offen".
+  const initialTab = useMemo<AssignmentStatus>(() => {
+    const present = new Set(rides.map((r) => r.assignmentStatus))
+    return ASSIGNMENT_STATUS_ORDER.find((s) => present.has(s)) ?? "offen"
+  }, [rides])
+
+  const [activeTab, setActiveTab] = useState<AssignmentStatus>(initialTab)
+  const [selectedRideId, setSelectedRideId] = useState<string | null>(null)
+  const [detailRideId, setDetailRideId] = useState<string | null>(null)
+  const [sheetOpen, setSheetOpen] = useState(false)
+
+  const handleSelectRide = useCallback((rideId: string) => {
+    // Toggle: clicking the active ride again de-selects it.
+    setSelectedRideId((current) => (current === rideId ? null : rideId))
+  }, [])
+
+  const handleOpenDetail = useCallback((rideId: string) => {
+    setDetailRideId(rideId)
+    setSheetOpen(true)
+  }, [])
+
+  const activeRide = useMemo(
+    () => rides.find((r) => r.id === selectedRideId) ?? null,
+    [rides, selectedRideId]
+  )
+
+  return (
+    <>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_minmax(320px,420px)]">
+        <RideColumn
+          rides={rides}
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
+          selectedRideId={selectedRideId}
+          onSelectRide={handleSelectRide}
+          onOpenDetail={handleOpenDetail}
+        />
+        <DriverColumn drivers={drivers} activeRide={activeRide} />
+      </div>
+
+      <RideQuickSheet
+        rideId={detailRideId}
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+      />
+    </>
+  )
+}

--- a/src/lib/acceptance/deadlines.ts
+++ b/src/lib/acceptance/deadlines.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure SLA deadline math for the acceptance flow (concept §3.3).
+ *
+ * This module is intentionally FREE of any server-only dependency (no admin
+ * Supabase client, no mail transport) so it can be imported from BOTH the cron
+ * engine (`engine.ts`) and client-side UI (the dispatch split-view countdown,
+ * #171) without dragging Node-only modules like `nodemailer` into the browser
+ * bundle. `engine.ts` re-exports these symbols for backward compatibility.
+ *
+ * `nextDeadline` is the single source of truth shared by the cron escalation and
+ * the UI countdown, so both compute identical deadlines from the same SLA
+ * windows.
+ */
+
+import { zurichWallTimeToUtc } from "@/lib/utils/dates"
+import {
+  NORMAL_SLA_WINDOWS,
+  SHORT_NOTICE_SLA_WINDOWS,
+  SHORT_NOTICE_THRESHOLD_MINUTES,
+} from "./constants"
+import type { AcceptanceStage, NextDeadline, SLAWindows } from "./types"
+
+const MS_PER_MINUTE = 60 * 1000
+
+/**
+ * Determine if a ride is short-notice based on its start time.
+ * Short-notice = ride start is less than SHORT_NOTICE_THRESHOLD_MINUTES (48h)
+ * from now. The ride date + pickup time are wall-clock values in Europe/Zurich
+ * and are converted to an absolute instant so the comparison is timezone-safe
+ * (the server runtime is UTC).
+ */
+export function isShortNotice(rideDate: string, pickupTime: string): boolean {
+  const pickupInstantMs = zurichWallTimeToUtc(rideDate, pickupTime).getTime()
+  const diffMinutes = (pickupInstantMs - Date.now()) / MS_PER_MINUTE
+  return diffMinutes < SHORT_NOTICE_THRESHOLD_MINUTES
+}
+
+/**
+ * Get the appropriate SLA windows based on short-notice status.
+ */
+export function getSLAWindows(shortNotice: boolean): SLAWindows {
+  return shortNotice ? SHORT_NOTICE_SLA_WINDOWS : NORMAL_SLA_WINDOWS
+}
+
+/** Minimal shape needed to compute a deadline (subset of acceptance_tracking). */
+export interface DeadlineInput {
+  stage: AcceptanceStage
+  is_short_notice: boolean
+  notified_at: string
+}
+
+/**
+ * Compute the next escalation deadline for a tracking record.
+ *
+ * Single source of truth shared by the cron engine and the UI countdown, so
+ * both compute identical deadlines from the same SLA windows. Returns null for
+ * terminal stages or stages with nothing left to escalate.
+ *
+ * Note: per concept §3.3 the flow is `notified → reminder_1 → timed_out`
+ * (one reminder). Legacy `reminder_2` records still escalate to `timed_out`.
+ */
+export function nextDeadline(tracking: DeadlineInput): NextDeadline | null {
+  const windows = getSLAWindows(tracking.is_short_notice)
+  const notifiedAtMs = new Date(tracking.notified_at).getTime()
+
+  switch (tracking.stage) {
+    case "notified":
+      return {
+        nextStage: "reminder_1",
+        dueAt: new Date(notifiedAtMs + windows.reminder1 * MS_PER_MINUTE),
+      }
+    case "reminder_1":
+    case "reminder_2":
+      return {
+        nextStage: "timed_out",
+        dueAt: new Date(notifiedAtMs + windows.timeout * MS_PER_MINUTE),
+      }
+    default:
+      return null
+  }
+}

--- a/src/lib/acceptance/engine.ts
+++ b/src/lib/acceptance/engine.ts
@@ -1,80 +1,23 @@
 import { createAdminClient } from "@/lib/supabase/admin"
-import { zurichWallTimeToUtc } from "@/lib/utils/dates"
 import { recordAssignmentEvent } from "./events"
-import {
-  NORMAL_SLA_WINDOWS,
-  SHORT_NOTICE_SLA_WINDOWS,
-  SHORT_NOTICE_THRESHOLD_MINUTES,
-  ACTIVE_STAGES,
-} from "./constants"
+import { ACTIVE_STAGES } from "./constants"
+import { isShortNotice, nextDeadline } from "./deadlines"
 import type {
   AcceptanceStage,
   RejectionReason,
   ResolutionMethod,
   EscalationResult,
-  NextDeadline,
-  SLAWindows,
 } from "./types"
 
-const MS_PER_MINUTE = 60 * 1000
-
-/**
- * Determine if a ride is short-notice based on its start time.
- * Short-notice = ride start is less than SHORT_NOTICE_THRESHOLD_MINUTES (48h)
- * from now. The ride date + pickup time are wall-clock values in Europe/Zurich
- * and are converted to an absolute instant so the comparison is timezone-safe
- * (the server runtime is UTC).
- */
-export function isShortNotice(rideDate: string, pickupTime: string): boolean {
-  const pickupInstantMs = zurichWallTimeToUtc(rideDate, pickupTime).getTime()
-  const diffMinutes = (pickupInstantMs - Date.now()) / MS_PER_MINUTE
-  return diffMinutes < SHORT_NOTICE_THRESHOLD_MINUTES
-}
-
-/**
- * Get the appropriate SLA windows based on short-notice status.
- */
-export function getSLAWindows(shortNotice: boolean): SLAWindows {
-  return shortNotice ? SHORT_NOTICE_SLA_WINDOWS : NORMAL_SLA_WINDOWS
-}
-
-/** Minimal shape needed to compute a deadline (subset of acceptance_tracking). */
-export interface DeadlineInput {
-  stage: AcceptanceStage
-  is_short_notice: boolean
-  notified_at: string
-}
-
-/**
- * Compute the next escalation deadline for a tracking record.
- *
- * Single source of truth shared by the cron engine (below) and the UI countdown
- * on ride cards, so both compute identical deadlines from the same SLA windows.
- * Returns null for terminal stages or stages with nothing left to escalate.
- *
- * Note: per concept §3.3 the flow is `notified → reminder_1 → timed_out`
- * (one reminder). Legacy `reminder_2` records still escalate to `timed_out`.
- */
-export function nextDeadline(tracking: DeadlineInput): NextDeadline | null {
-  const windows = getSLAWindows(tracking.is_short_notice)
-  const notifiedAtMs = new Date(tracking.notified_at).getTime()
-
-  switch (tracking.stage) {
-    case "notified":
-      return {
-        nextStage: "reminder_1",
-        dueAt: new Date(notifiedAtMs + windows.reminder1 * MS_PER_MINUTE),
-      }
-    case "reminder_1":
-    case "reminder_2":
-      return {
-        nextStage: "timed_out",
-        dueAt: new Date(notifiedAtMs + windows.timeout * MS_PER_MINUTE),
-      }
-    default:
-      return null
-  }
-}
+// Pure SLA deadline math now lives in `./deadlines` (server + client safe).
+// Re-export it here so existing `@/lib/acceptance/engine` imports keep working
+// and `nextDeadline` remains the single source of truth (concept §6, #171).
+export {
+  isShortNotice,
+  getSLAWindows,
+  nextDeadline,
+  type DeadlineInput,
+} from "./deadlines"
 
 /**
  * Cancel any active acceptance tracking for a ride.

--- a/src/lib/dispatch/__tests__/assignment-status.test.ts
+++ b/src/lib/dispatch/__tests__/assignment-status.test.ts
@@ -12,7 +12,7 @@ import {
   type AssignmentStatus,
 } from "../assignment-status"
 import type { Enums } from "@/lib/types/database"
-import type { DeadlineInput } from "@/lib/acceptance/engine"
+import type { DeadlineInput } from "@/lib/acceptance/deadlines"
 
 type RideStatus = Enums<"ride_status">
 

--- a/src/lib/dispatch/__tests__/assignment-status.test.ts
+++ b/src/lib/dispatch/__tests__/assignment-status.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest"
+import {
+  deriveAssignmentStatus,
+  deriveAngefragtTiming,
+  ASSIGNMENT_STATUS_ORDER,
+  ASSIGNMENT_RIDE_STATUSES,
+  ASSIGNMENT_STATUS_LABELS,
+  ASSIGNMENT_STATUS_COLORS,
+  ASSIGNMENT_STATUS_DOT_COLORS,
+  ASSIGNMENT_STATUS_BORDER_COLORS,
+  ASSIGNMENT_STATUS_TAB_ACTIVE_COLORS,
+  type AssignmentStatus,
+} from "../assignment-status"
+import type { Enums } from "@/lib/types/database"
+import type { DeadlineInput } from "@/lib/acceptance/engine"
+
+type RideStatus = Enums<"ride_status">
+
+// Every ride_status value, so the mapping stays exhaustive if the enum changes.
+const ALL_RIDE_STATUSES: RideStatus[] = [
+  "unplanned",
+  "planned",
+  "confirmed",
+  "rejected",
+  "in_progress",
+  "picked_up",
+  "arrived",
+  "completed",
+  "cancelled",
+  "no_show",
+]
+
+describe("deriveAssignmentStatus — the 4 display buckets", () => {
+  it("maps the four assignment-relevant statuses 1:1", () => {
+    expect(deriveAssignmentStatus("unplanned")).toBe<AssignmentStatus>("offen")
+    expect(deriveAssignmentStatus("planned")).toBe<AssignmentStatus>("angefragt")
+    expect(deriveAssignmentStatus("confirmed")).toBe<AssignmentStatus>(
+      "bestaetigt"
+    )
+    expect(deriveAssignmentStatus("rejected")).toBe<AssignmentStatus>(
+      "abgelehnt"
+    )
+  })
+
+  it("returns null for in-transport and terminal statuses (out of scope §0)", () => {
+    for (const status of [
+      "in_progress",
+      "picked_up",
+      "arrived",
+      "completed",
+      "cancelled",
+      "no_show",
+    ] as RideStatus[]) {
+      expect(deriveAssignmentStatus(status)).toBeNull()
+    }
+  })
+
+  it("covers every ride_status value (no throw, valid bucket or null)", () => {
+    for (const status of ALL_RIDE_STATUSES) {
+      const result = deriveAssignmentStatus(status)
+      if (result !== null) {
+        expect(ASSIGNMENT_STATUS_ORDER).toContain(result)
+      }
+    }
+  })
+
+  it("exactly the four ASSIGNMENT_RIDE_STATUSES derive to a non-null bucket", () => {
+    const nonNull = ALL_RIDE_STATUSES.filter(
+      (s) => deriveAssignmentStatus(s) !== null
+    )
+    expect([...nonNull].sort()).toEqual([...ASSIGNMENT_RIDE_STATUSES].sort())
+  })
+
+  it("introduces no new enum values — buckets are a closed set of four", () => {
+    expect(ASSIGNMENT_STATUS_ORDER).toHaveLength(4)
+    expect(ASSIGNMENT_STATUS_ORDER).toEqual([
+      "offen",
+      "angefragt",
+      "bestaetigt",
+      "abgelehnt",
+    ])
+  })
+})
+
+describe("deriveAngefragtTiming — SLA overdue marker (reuses nextDeadline)", () => {
+  const NOTIFIED = "2026-07-16T08:00:00.000Z"
+
+  it("no tracking → not overdue, no deadline", () => {
+    expect(deriveAngefragtTiming(null)).toEqual({ overdue: false, dueAt: null })
+  })
+
+  it("fresh 'notified' before the reminder window → pending, not overdue", () => {
+    const tracking: DeadlineInput = {
+      stage: "notified",
+      is_short_notice: false,
+      notified_at: NOTIFIED,
+    }
+    // 1h after notification — the 24h reminder is far away.
+    const now = new Date("2026-07-16T09:00:00.000Z")
+    const timing = deriveAngefragtTiming(tracking, now)
+    expect(timing.overdue).toBe(false)
+    // dueAt = notified + 24h (normal reminder window).
+    expect(timing.dueAt?.toISOString()).toBe("2026-07-17T08:00:00.000Z")
+  })
+
+  it("'notified' past the reminder window → overdue", () => {
+    const tracking: DeadlineInput = {
+      stage: "notified",
+      is_short_notice: false,
+      notified_at: NOTIFIED,
+    }
+    // 25h later — past the 24h reminder deadline.
+    const now = new Date("2026-07-17T09:00:00.000Z")
+    expect(deriveAngefragtTiming(tracking, now).overdue).toBe(true)
+  })
+
+  it("short-notice uses the shortened 4h window", () => {
+    const tracking: DeadlineInput = {
+      stage: "notified",
+      is_short_notice: true,
+      notified_at: NOTIFIED,
+    }
+    const now = new Date("2026-07-16T09:00:00.000Z")
+    const timing = deriveAngefragtTiming(tracking, now)
+    // dueAt = notified + 4h.
+    expect(timing.dueAt?.toISOString()).toBe("2026-07-16T12:00:00.000Z")
+    expect(timing.overdue).toBe(false)
+  })
+
+  it("'timed_out' stage → overdue with no further deadline", () => {
+    const tracking: DeadlineInput = {
+      stage: "timed_out",
+      is_short_notice: false,
+      notified_at: NOTIFIED,
+    }
+    expect(deriveAngefragtTiming(tracking)).toEqual({
+      overdue: true,
+      dueAt: null,
+    })
+  })
+})
+
+describe("display token families are complete for all four buckets", () => {
+  for (const status of ASSIGNMENT_STATUS_ORDER) {
+    it(`has label + all color tokens for "${status}"`, () => {
+      expect(ASSIGNMENT_STATUS_LABELS[status]).toBeTruthy()
+      expect(ASSIGNMENT_STATUS_COLORS[status]).toBeTruthy()
+      expect(ASSIGNMENT_STATUS_DOT_COLORS[status]).toBeTruthy()
+      expect(ASSIGNMENT_STATUS_BORDER_COLORS[status]).toBeTruthy()
+      expect(ASSIGNMENT_STATUS_TAB_ACTIVE_COLORS[status]).toBeTruthy()
+    })
+  }
+})

--- a/src/lib/dispatch/assignment-status.ts
+++ b/src/lib/dispatch/assignment-status.ts
@@ -27,7 +27,7 @@
  */
 
 import type { Enums } from "@/lib/types/database"
-import { nextDeadline, type DeadlineInput } from "@/lib/acceptance/engine"
+import { nextDeadline, type DeadlineInput } from "@/lib/acceptance/deadlines"
 
 type RideStatus = Enums<"ride_status">
 

--- a/src/lib/dispatch/assignment-status.ts
+++ b/src/lib/dispatch/assignment-status.ts
@@ -1,0 +1,172 @@
+/**
+ * Assignment status: the dispatcher-facing status model for the /dispatch
+ * split-view (M15, Issue #168).
+ *
+ * The split-view groups rides into exactly FOUR buckets — Offen · Angefragt ·
+ * Bestätigt · Abgelehnt. Per the AC these are a pure DISPLAY derivation from the
+ * existing `ride.status` lifecycle (+ the active `acceptance_tracking` record for
+ * timing enrichment). They introduce NO new enum values.
+ *
+ * Why `ride.status` is authoritative for the bucket:
+ * The ride state machine (`src/lib/rides/status-machine.ts`) already encodes the
+ * acceptance outcome — `planned` = a driver was requested, `confirmed` = the
+ * driver accepted, `rejected` = the driver declined (holding state until the
+ * dispatcher re-assigns). So the four buckets map 1:1 onto four lifecycle
+ * statuses. `acceptance_tracking` is layered on top only to enrich the
+ * "Angefragt" bucket with the SLA countdown / overdue marker (via the shared
+ * `nextDeadline` single source of truth) — see `deriveAngefragtTiming`.
+ *
+ * Rides outside the assignment question (in_progress … no_show) return `null`
+ * and are intentionally NOT shown in the split-view (concept §0 scope: the page
+ * answers only "who still drives this?").
+ *
+ * Color system (concept §6, design-owned by Kim): a token family kept SEPARATE
+ * from `RIDE_STATUS_*` (4 vs 10 states, partly different meaning) but derived
+ * from the same Tailwind families for visual consistency. Badges always render
+ * dot + text, never color alone (accessibility).
+ */
+
+import type { Enums } from "@/lib/types/database"
+import { nextDeadline, type DeadlineInput } from "@/lib/acceptance/engine"
+
+type RideStatus = Enums<"ride_status">
+
+// =============================================================================
+// STATUS MODEL
+// =============================================================================
+
+export type AssignmentStatus = "offen" | "angefragt" | "bestaetigt" | "abgelehnt"
+
+/**
+ * Ordered list of the four buckets, matching the tab order in the UI
+ * (concept §2 / Kim §2). Single source of truth for iteration.
+ */
+export const ASSIGNMENT_STATUS_ORDER: readonly AssignmentStatus[] = [
+  "offen",
+  "angefragt",
+  "bestaetigt",
+  "abgelehnt",
+] as const
+
+/**
+ * The set of `ride.status` values that belong on the split-view. Used to scope
+ * the page query so terminal / in-transport rides never load (concept §0).
+ */
+export const ASSIGNMENT_RIDE_STATUSES: readonly RideStatus[] = [
+  "unplanned",
+  "planned",
+  "confirmed",
+  "rejected",
+] as const
+
+/**
+ * Derive the split-view bucket from a ride's lifecycle status.
+ * Pure, no new enum values. Returns `null` for rides outside the assignment
+ * question (they are filtered out of the split-view).
+ */
+export function deriveAssignmentStatus(
+  rideStatus: RideStatus
+): AssignmentStatus | null {
+  switch (rideStatus) {
+    case "unplanned":
+      return "offen"
+    case "planned":
+      return "angefragt"
+    case "confirmed":
+      return "bestaetigt"
+    case "rejected":
+      return "abgelehnt"
+    // in_progress, picked_up, arrived, completed, cancelled, no_show
+    default:
+      return null
+  }
+}
+
+// =============================================================================
+// ANGEFRAGT TIMING (SLA overdue marker — concept §3.3 / §6)
+// =============================================================================
+
+/**
+ * Server-computed timing for an "Angefragt" ride, derived from its active
+ * acceptance tracking. This is the "+ acceptance_tracking" half of the AC
+ * derivation. It reuses `nextDeadline` — the SAME function the cron/reminder
+ * engine uses — so the UI never re-derives SLA windows (concept §6, #171).
+ *
+ * NOTE: this returns a static, request-time snapshot (an `overdue` flag and the
+ * absolute `dueAt`). The live per-minute countdown itself is Issue #171; this
+ * only provides the anchor it will tick against.
+ */
+export interface AngefragtTiming {
+  /** Whether the next SLA deadline has already passed (reminder/alarm due). */
+  overdue: boolean
+  /** Absolute instant of the next escalation, or null if none pending. */
+  dueAt: Date | null
+}
+
+export function deriveAngefragtTiming(
+  tracking: DeadlineInput | null,
+  now: Date = new Date()
+): AngefragtTiming {
+  if (!tracking) {
+    return { overdue: false, dueAt: null }
+  }
+  // Already escalated to timeout: overdue, nothing left to count down to.
+  if (tracking.stage === "timed_out") {
+    return { overdue: true, dueAt: null }
+  }
+  const deadline = nextDeadline(tracking)
+  if (!deadline) {
+    return { overdue: false, dueAt: null }
+  }
+  return {
+    overdue: now.getTime() >= deadline.dueAt.getTime(),
+    dueAt: deadline.dueAt,
+  }
+}
+
+// =============================================================================
+// DISPLAY TOKENS (labels + colors — concept §6)
+// =============================================================================
+
+/** German labels for the four buckets. */
+export const ASSIGNMENT_STATUS_LABELS: Record<AssignmentStatus, string> = {
+  offen: "Offen",
+  angefragt: "Angefragt",
+  bestaetigt: "Bestätigt",
+  abgelehnt: "Abgelehnt",
+}
+
+/** Badge background + text classes (concept §6, WCAG AA). */
+export const ASSIGNMENT_STATUS_COLORS: Record<AssignmentStatus, string> = {
+  offen: "bg-red-100 text-red-800",
+  angefragt: "bg-amber-100 text-amber-800",
+  bestaetigt: "bg-green-100 text-green-800",
+  abgelehnt: "bg-rose-100 text-rose-800",
+}
+
+/** Solid dot color inside the badge. */
+export const ASSIGNMENT_STATUS_DOT_COLORS: Record<AssignmentStatus, string> = {
+  offen: "bg-red-600",
+  angefragt: "bg-amber-500",
+  bestaetigt: "bg-green-600",
+  abgelehnt: "bg-rose-600",
+}
+
+/** Left-border color for ride cards (encodes status before the badge is read). */
+export const ASSIGNMENT_STATUS_BORDER_COLORS: Record<AssignmentStatus, string> = {
+  offen: "border-l-red-600",
+  angefragt: "border-l-amber-400",
+  bestaetigt: "border-l-green-500",
+  abgelehnt: "border-l-rose-500",
+}
+
+/** Solid fill for the ACTIVE status tab (inactive tabs use bg-muted). */
+export const ASSIGNMENT_STATUS_TAB_ACTIVE_COLORS: Record<
+  AssignmentStatus,
+  string
+> = {
+  offen: "bg-red-600 text-white",
+  angefragt: "bg-amber-500 text-white",
+  bestaetigt: "bg-green-600 text-white",
+  abgelehnt: "bg-rose-600 text-white",
+}


### PR DESCRIPTION
Closes #168

Grundgerüst der Dispositions-Split-View (M15, Phase 15.2). `/dispatch` wird zur wöchentlichen Zuteilungsansicht: **Fahrten links, Fahrer rechts**, vier Status-Tabs, Wochen-Navigation als Standard-Periode. Reine UI + Queries, **keine DB-Migration**.

## Umsetzung von Kims UX-Spec (Kommentar in #168)

- **§0 Anzeige-Status ≠ Enum**: neuer Ableitungs-Layer `src/lib/dispatch/assignment-status.ts`. `deriveAssignmentStatus(ride.status)` bildet die vier Buckets ab (`unplanned→Offen`, `planned→Angefragt`, `confirmed→Bestätigt`, `rejected→Abgelehnt`), alle übrigen Lifecycle-Status → `null` (nicht Teil der Zuteilungsfrage, §0-Scope). **Keine neuen Enum-Werte.** `ride.status` ist autoritativ, weil die State-Machine das Annahme-Ergebnis bereits kodiert; `acceptance_tracking` liefert nur den Überfällig-Marker via bestehender `nextDeadline()`-SSOT (`deriveAngefragtTiming`, Countdown-UI folgt in #171).
- **§1 Layout**: `grid lg:grid-cols-[1fr_minmax(320px,420px)]`, Fahrer-Panel `sticky`, auf Mobile gestapelt.
- **§2 Fahrten-Panel**: Status-Tabs mit Zähler; „Abgelehnt" nur bei Zähler > 0, die anderen drei immer sichtbar; kein „Alle"-Tab. Karten-Anatomie: Datum + Zeit, Von → Nach, Patient + Bedarf, „↩ Rückfahrt HH:MM" (verknüpfte `parent_ride_id`), Angefragt-Fahrer, Abgelehnt-Vermerk aus `assignment_events`, Überfällig-Badge.
- **§3 Fahrer-Panel**: flache Liste mit heutigem Slot-Status + Fahrtenzahl der Periode. Kontext-Filterung (Verfügbar/Konflikt/Nicht verfügbar) ist bewusst #169 — Panel erhält die aktive Fahrt aber schon als Prop.
- **§6 Farbsystem**: eigene Token-Familie getrennt von `RIDE_STATUS_*`, Badge immer Punkt + Text.
- Karten-Klick **aktiviert** die Fahrt (Andockpunkt für #169); `RideQuickSheet` bleibt Detail-Surface.

## Security-Vorgaben

- **#180**: Seite serverseitig auf `admin`/`operator` gegated (`requireAuth`), Redirect **vor** jedem Datenrender.
- **#187**: Absenzen neutral als „Nicht verfügbar bis X" — Absenz-**Grund** (z.B. Krankheit) wird in der Karten-UI **nie** exponiert.
- **#179**: Fahrt-Karten zeigen nur operativ nötige Patientendaten (Name, Ort, Bedarf) — keine Adresse. Dies ist die Staff-Vollsicht, getrennt von der gestuften Fahrer-Sicht.

## Scope-Abgrenzung (bewusst NICHT enthalten)

Kontext-Filterung/Zuweisen-Flow (#169), Drag & Drop (#170), Live-Countdown (#171), Benachrichtigungs-Badge (#173) sind separate Issues. Struktur (aktive-Fahrt-State, Timing-Anker, Token-Familie) ist so gebaut, dass diese andocken können, ohne das Layout anzufassen.

**Kein Funktionsverlust**: Die Tagesansicht (`?date=`) mit voller Zuweisungs-, Absenz-Sperr-, Zeitkonflikt- und Out-of-Availability-Logik (`DispatchBoard`) bleibt unverändert erreichbar (Link „Tagesansicht" im Header). Die bisherige Wochen-Kalendergrid-Route (`DispatchWeekView`) wird durch die Split-View ersetzt; die Komponente bleibt vorerst im Repo (Kandidat für spätere Entfernung).

## Datenlader

Wiederverwendung von `loadDriverSchedules` + `resolveDriverDayStatus` (bundled, kein N+1). Follow-up-Queries (`acceptance_tracking`, `assignment_events`-Ablehnungen) sind per `ride_id` gescoped.

## Checks

- `tsc --noEmit`: grün
- `next lint`: grün (0 Errors; nur vorbestehende Warnings)
- `vitest run`: **1082 Tests grün**, davon 14 neu für das Status-Mapping (`src/lib/dispatch/__tests__/assignment-status.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)