### PR TITLE
docs(help): Hilfe-System gegen aktuellen App-Stand aktualisiert

### DIFF
--- a/src/lib/help/content/abrechnung.ts
+++ b/src/lib/help/content/abrechnung.ts
@@ -43,7 +43,7 @@ export const abrechnung: HelpArticle = {
       blocks: [
         {
           type: "paragraph",
-          text: "Alles rund ums Geld finden Sie oben im Menü unter „Finanzen“. Der frühere Menüpunkt „Verrechnung“ ist darin aufgegangen – alte Lesezeichen funktionieren weiter und leiten automatisch auf „Finanzen → Export“.",
+          text: "Alles rund ums Geld finden Sie links im Menü unter „Finanzen“. Der frühere Menüpunkt „Verrechnung“ ist darin aufgegangen – alte Lesezeichen funktionieren weiter und leiten automatisch auf „Finanzen → Export“.",
         },
         {
           type: "list",

--- a/src/lib/help/content/admin-einstellungen.ts
+++ b/src/lib/help/content/admin-einstellungen.ts
@@ -106,6 +106,43 @@ export const adminEinstellungen: HelpArticle = {
       ],
     },
     {
+      id: "geocoding",
+      heading: "Geocoding: Adressen auf der Karte verorten",
+      blocks: [
+        {
+          type: "paragraph",
+          text: "Damit Fahrten auf der Karte erscheinen und Routen berechnet werden können, braucht jede Patienten- und Zieladresse eine Position (Koordinaten). Das geschieht normalerweise automatisch, sobald Sie eine Adresse anlegen oder ändern. Der Reiter „Geocoding“ zeigt den Stand und lässt fehlende Positionen nachtragen.",
+        },
+        {
+          type: "paragraph",
+          text: "Oben sehen Sie je eine Übersicht für Patienten und für Ziele: wie viele Adressen bereits verortet sind und wie viele noch offen oder fehlgeschlagen sind.",
+        },
+        {
+          type: "steps",
+          steps: [
+            {
+              title: "Backfill starten",
+              text: "Klicken Sie auf „Backfill starten“. Die App arbeitet die offenen Adressen in Blöcken ab. Ein Fortschrittsbalken zeigt, wie viele verarbeitet sind, samt Anzahl erfolgreich, fehlgeschlagen und verbleibend.",
+            },
+            {
+              title: "Laufen lassen oder abbrechen",
+              text: "Der Lauf kann einige Minuten dauern. Mit „Abbrechen“ stoppen Sie nach dem aktuellen Block; bereits verortete Adressen bleiben gespeichert. Sie können jederzeit erneut starten – fertige Adressen werden übersprungen.",
+            },
+          ],
+        },
+        {
+          type: "callout",
+          variant: "info",
+          text: "Adressen, die Google nicht findet – etwa wegen Tippfehlern oder unvollständiger Angaben –, erscheinen am Ende in der Liste „Nicht geocodierbar“. Korrigieren Sie diese Adressen im jeweiligen Patienten- oder Ziel-Stammdatensatz; beim Speichern wird die Position automatisch neu ermittelt.",
+        },
+        {
+          type: "callout",
+          variant: "tip",
+          text: "Von Hand müssen Sie das selten anstossen: Neue oder geänderte Adressen werden sofort verortet, und ein täglicher Hintergrundlauf holt zuvor fehlgeschlagene Adressen von selbst nach.",
+        },
+      ],
+    },
+    {
       id: "system-sicherheit",
       heading: "System und Sicherheit",
       blocks: [
@@ -113,7 +150,7 @@ export const adminEinstellungen: HelpArticle = {
           type: "list",
           items: [
             "„System“: zeigt zur Information den Zustand der App und der angebundenen Dienste. Hier lässt sich nichts einstellen – die Seite dient nur dem Nachschauen.",
-            "„Geocoding“: hier können Adressen, die noch keine Position auf der Karte haben, erneut ermittelt werden.",
+            "„Geocoding“: hier tragen Sie fehlende Positionen von Adressen auf der Karte nach (siehe Abschnitt „Geocoding“ oben).",
             "„Sicherheit“: hier ändern Sie Ihr eigenes Passwort und richten bei Bedarf eine Zwei-Faktor-Anmeldung ein.",
           ],
         },

--- a/src/lib/help/content/dispatch-board.ts
+++ b/src/lib/help/content/dispatch-board.ts
@@ -26,7 +26,7 @@ export const dispatchBoard: HelpArticle = {
       blocks: [
         {
           type: "paragraph",
-          text: "Im Bereich „Disposition“ planen Sie einen Tag: Sie sehen alle Fahrten und teilen ihnen Fahrerinnen und Fahrer zu. Klicken Sie dazu oben im Menü auf „Disposition“.",
+          text: "Im Bereich „Disposition“ planen Sie einen Tag: Sie sehen alle Fahrten und teilen ihnen Fahrerinnen und Fahrer zu. Klicken Sie dazu links im Menü auf „Disposition“.",
         },
         {
           type: "paragraph",

--- a/src/lib/help/content/erste-schritte.ts
+++ b/src/lib/help/content/erste-schritte.ts
@@ -50,7 +50,7 @@ export const ersteSchritte: HelpArticle = {
           type: "callout",
           variant: "warning",
           title: "Passwort vergessen?",
-          text: "Wenn Ihr Passwort nicht funktioniert, wenden Sie sich an Ihre Ansprechperson in der Administration. Sie kann Ihnen ein neues Passwort einrichten.",
+          text: "Klicken Sie auf der Anmeldeseite auf „Passwort vergessen?“. Sie erhalten dann per E-Mail einen Link, mit dem Sie sich selbst ein neues Passwort setzen können. Klappt das nicht, wenden Sie sich an Ihre Ansprechperson in der Administration.",
         },
       ],
     },

--- a/src/lib/help/content/fahrer-fahrt-annehmen.ts
+++ b/src/lib/help/content/fahrer-fahrt-annehmen.ts
@@ -32,7 +32,7 @@ export const fahrerFahrtAnnehmen: HelpArticle = {
         {
           type: "callout",
           variant: "info",
-          text: "Bitte antworten Sie möglichst zügig. Der Link in der E-Mail ist 48 Stunden gültig. Bleibt eine Antwort aus, erhalten Sie eine Erinnerung, und die Einteilung fragt gegebenenfalls eine andere Fahrerin oder einen anderen Fahrer an.",
+          text: "Bitte antworten Sie möglichst zügig. Bei Fahrten mit etwas Vorlauf haben Sie in der Regel bis zu 48 Stunden Zeit; bei kurzfristigen Fahrten (Start in weniger als 48 Stunden) ist das Zeitfenster deutlich kürzer. Bleibt eine Antwort aus, erhalten Sie eine Erinnerung, und die Einteilung fragt gegebenenfalls eine andere Fahrerin oder einen anderen Fahrer an.",
         },
       ],
     },

--- a/src/lib/help/content/fahrer-meine-fahrten.ts
+++ b/src/lib/help/content/fahrer-meine-fahrten.ts
@@ -26,7 +26,7 @@ export const fahrerMeineFahrten: HelpArticle = {
       blocks: [
         {
           type: "paragraph",
-          text: "Unter „Meine Fahrten“ sehen Sie alle Fahrten, die Ihnen zugeteilt wurden. Klicken Sie dazu oben im Menü auf „Meine Fahrten“. Die App zeigt zunächst den heutigen Tag.",
+          text: "Unter „Meine Fahrten“ sehen Sie alle Fahrten, die Ihnen zugeteilt wurden. Klicken Sie dazu links im Menü auf „Meine Fahrten“. Die App zeigt zunächst den heutigen Tag.",
         },
         // TODO(content): Screenshot der Fahrer-Ansicht "Meine Fahrten" mit einer Fahrtkarte.
       ],
@@ -46,7 +46,8 @@ export const fahrerMeineFahrten: HelpArticle = {
             "den Namen der Person und das Ziel,",
             "die Richtung (Hinfahrt, Rückfahrt oder Hin & Rück),",
             "einen Fortschrittsbalken, der den Stand der Fahrt zeigt,",
-            "eine Schaltfläche zum Starten der Navigation.",
+            "eine Schaltfläche zum Starten der Navigation,",
+            "einen Link „Details anzeigen“ zur Detailseite mit Kartenansicht.",
           ],
         },
         {
@@ -54,6 +55,21 @@ export const fahrerMeineFahrten: HelpArticle = {
           variant: "tip",
           title: "Zum Ziel navigieren",
           text: "Die grosse Schaltfläche führt Sie mit Google Maps zur richtigen Adresse. Vor dem Abholen heisst sie „Abholung ansteuern“ (zur Person), danach „Ziel ansteuern“ (zum Ziel). Die Navigation öffnet sich in einem neuen Fenster.",
+        },
+      ],
+    },
+    {
+      id: "detailseite",
+      heading: "Die Route auf der Karte ansehen",
+      blocks: [
+        {
+          type: "paragraph",
+          text: "Über „Details anzeigen“ auf einer Fahrtkarte öffnen Sie die Detailseite der Fahrt. Dort finden Sie unter anderem eine Karte, die den Weg von der Abholadresse (roter Punkt „H“) zum Ziel (blauer Punkt „Z“) zeigt.",
+        },
+        {
+          type: "callout",
+          variant: "info",
+          text: "Ist für eine Fahrt noch keine Route hinterlegt, zeigt die Karte nur die beiden Punkte ohne Verbindungslinie. Für die eigentliche Turn-by-turn-Navigation nutzen Sie weiterhin die Schaltflächen „Abholung ansteuern“ bzw. „Ziel ansteuern“.",
         },
       ],
     },

--- a/src/lib/help/content/fahrer-verfuegbarkeit.ts
+++ b/src/lib/help/content/fahrer-verfuegbarkeit.ts
@@ -26,7 +26,7 @@ export const fahrerVerfuegbarkeit: HelpArticle = {
       blocks: [
         {
           type: "paragraph",
-          text: "Damit die Einteilung Ihnen passende Fahrten zuweisen kann, tragen Sie ein, wann Sie verfügbar sind. Klicken Sie dazu oben im Menü auf „Verfügbarkeit“.",
+          text: "Damit die Einteilung Ihnen passende Fahrten zuweisen kann, tragen Sie ein, wann Sie verfügbar sind. Klicken Sie dazu links im Menü auf „Verfügbarkeit“.",
         },
         {
           type: "paragraph",

--- a/src/lib/help/content/fahrer-zuweisen.ts
+++ b/src/lib/help/content/fahrer-zuweisen.ts
@@ -37,7 +37,7 @@ export const fahrerZuweisen: HelpArticle = {
           steps: [
             {
               title: "Bereich „Disposition“ öffnen",
-              text: "Klicken Sie oben im Menü auf „Disposition“. Sie sehen den heutigen Tag mit allen Fahrten.",
+              text: "Klicken Sie links im Menü auf „Disposition“. Sie sehen den heutigen Tag mit allen Fahrten.",
             },
             {
               title: "Zum richtigen Tag wechseln",
@@ -69,9 +69,15 @@ export const fahrerZuweisen: HelpArticle = {
             },
             {
               title: "Fahrer anklicken",
-              text: "Klicken Sie den passenden Namen an. Die Zuweisung wird sofort gespeichert – Sie müssen nichts extra bestätigen.",
+              text: "Klicken Sie den passenden Namen an. Die Zuweisung wird in der Regel sofort gespeichert – Sie müssen nichts extra bestätigen.",
             },
           ],
+        },
+        {
+          type: "callout",
+          variant: "info",
+          title: "Abwesende und nicht verfügbare Fahrer",
+          text: "Fahrerinnen und Fahrer, die an diesem Tag abwesend sind, erscheinen in der Liste ausgegraut und lassen sich nicht auswählen. Wählen Sie jemanden, der zu dieser Zeit nicht als verfügbar eingetragen ist, fragt die App zur Sicherheit noch einmal nach („Ausserhalb der Verfügbarkeit – Trotzdem zuweisen?“).",
         },
         {
           type: "callout",

--- a/src/lib/help/content/fahrt-erfassen.ts
+++ b/src/lib/help/content/fahrt-erfassen.ts
@@ -72,19 +72,23 @@ export const fahrtErfassen: HelpArticle = {
       heading: "Das Formular ausfüllen",
       blocks: [
         {
+          type: "paragraph",
+          text: "Die Erfassung führt Sie in drei Schritten durch: „Wer“, „Wohin & wann“ und „Fahrt“.",
+        },
+        {
           type: "steps",
           steps: [
             {
-              title: "Patientin oder Patient wählen",
-              text: "Tippen Sie in das Feld „Patient“ den Namen ein. Während Sie tippen, werden passende Einträge vorgeschlagen. Klicken Sie den richtigen an.",
+              title: "Schritt „Wer“: Patientin oder Patient wählen",
+              text: "Tippen Sie den Namen ein. Während Sie tippen, werden passende Einträge vorgeschlagen – klicken Sie den richtigen an. Ist die Person noch nicht gespeichert, legen Sie sie direkt hier neu an.",
             },
             {
-              title: "Ziel wählen",
-              text: "Wählen Sie im Feld „Ziel“ auf die gleiche Weise den Ort, zu dem gefahren wird – zum Beispiel eine Arztpraxis oder ein Spital.",
+              title: "Schritt „Wohin & wann“: Ziel und Termin",
+              text: "Wählen Sie das Ziel – zum Beispiel eine Arztpraxis oder ein Spital. Tragen Sie „Terminbeginn“ und „Termindauer“ ein. Die passende Abholzeit schlägt die App rechts im Bereich „Abholzeiten“ automatisch als „Hin-Abholung“ vor.",
             },
             {
-              title: "Datum und Uhrzeit eintragen",
-              text: "Tragen Sie das Datum und die gewünschte Uhrzeit ein. Achten Sie darauf, ob es eine Hinfahrt, eine Rückfahrt oder beides ist.",
+              title: "Schritt „Fahrt“: Fahrt-Typ wählen",
+              text: "Legen Sie mit dem Umschalter fest, ob es eine „Hin + Rück“-Fahrt oder eine „Einzelfahrt (nur Hin)“ ist.",
             },
             {
               title: "Angaben prüfen",
@@ -92,17 +96,7 @@ export const fahrtErfassen: HelpArticle = {
             },
           ],
         },
-        {
-          type: "screenshot",
-          src: "/help/screenshots/fahrt-erfassen-formular.png",
-          alt: "Das ausgefüllte Fahrten-Formular mit den Feldern Patient, Ziel, Datum, Uhrzeit und Richtung.",
-          caption: "Das ausgefüllte Formular vor dem Speichern.",
-          markers: [
-            { number: 1, x: 30, y: 22, label: "Patient auswählen" },
-            { number: 2, x: 30, y: 40, label: "Ziel auswählen" },
-            { number: 3, x: 30, y: 58, label: "Datum und Uhrzeit" },
-          ],
-        },
+        // TODO(content): Screenshot der neuen 3-Schritt-Erfassung (/rides/erfassen) mit den Schritten „Wer“, „Wohin & wann“, „Fahrt“ und dem Panel „Abholzeiten“.
       ],
     },
     {
@@ -111,7 +105,7 @@ export const fahrtErfassen: HelpArticle = {
       blocks: [
         {
           type: "paragraph",
-          text: "Klicken Sie unten auf „Speichern“. Die Fahrt erscheint danach in der Fahrtenübersicht und kann eingeteilt werden.",
+          text: "Zum Abschluss haben Sie zwei Schaltflächen: „Speichern & zur Übersicht“ sichert die Fahrt und bringt Sie zurück zur Fahrtenübersicht. „Auftragsblatt“ speichert die Fahrt ebenfalls und öffnet zusätzlich das Auftragsblatt zum Ausdrucken. Die Fahrt kann danach eingeteilt werden.",
         },
         {
           type: "callout",

--- a/src/lib/help/content/patient-anlegen.ts
+++ b/src/lib/help/content/patient-anlegen.ts
@@ -39,7 +39,7 @@ export const patientAnlegen: HelpArticle = {
           steps: [
             {
               title: "Bereich „Patienten“ öffnen",
-              text: "Klicken Sie oben im Menü auf „Patienten“.",
+              text: "Klicken Sie links im Menü auf „Patienten“.",
             },
             {
               title: "Neue Person starten",
@@ -71,6 +71,10 @@ export const patientAnlegen: HelpArticle = {
             {
               title: "Notfallkontakt ergänzen (freiwillig)",
               text: "Unter „Notfallkontakt“ können Sie Name und Telefon einer Kontaktperson eintragen.",
+            },
+            {
+              title: "E-Mail für Quittungen (freiwillig)",
+              text: "Im Bereich „Rechnung & Zustellung“ können Sie unter „E-Mail (Quittungsversand)“ eine Adresse hinterlegen. Nur dann lassen sich Quittungen später per E-Mail zustellen. Bei Bedarf tragen Sie hier auch einen Kostenträger oder einen abweichenden Rechnungsempfänger ein.",
             },
           ],
         },

--- a/src/lib/help/content/serie-anlegen.ts
+++ b/src/lib/help/content/serie-anlegen.ts
@@ -44,7 +44,7 @@ export const serieAnlegen: HelpArticle = {
           steps: [
             {
               title: "Bereich „Fahrtserien“ öffnen",
-              text: "Klicken Sie oben im Menü auf „Fahrtserien“.",
+              text: "Klicken Sie links im Menü auf „Fahrtserien“.",
             },
             {
               title: "Neue Serie starten",


### PR DESCRIPTION
Umfassender Abgleich des Hilfe-Systems mit dem echten App-Stand. Zwei Review-Agenten haben alle Artikel faktisch gegen den Code geprüft; die bestätigten Diskrepanzen sind hier korrigiert.

## Inhaltliche Korrekturen
- **admin-einstellungen** — neuer Abschnitt „Geocoding" (Backfill-Oberfläche: Starten, Fortschritt, Abbrechen, Liste „Nicht geocodierbar", automatischer Nachzug).
- **fahrt-erfassen** — auf die neue **3-Schritt-Erfassung** (`/rides/erfassen`) umgestellt: „Wer / Wohin & wann / Fahrt", Terminbeginn+Termindauer, Fahrt-Typ-Umschalter, Buttons „Speichern & zur Übersicht" / „Auftragsblatt".
- **fahrer-meine-fahrten** — Detailseite mit **Karten-/Routenansicht** ergänzt (Routen-Hinweis).
- **erste-schritte** — Selfservice „Passwort vergessen?" ergänzt.
- **patient-anlegen** — Feld „E-Mail (Quittungsversand)" ergänzt.
- **fahrer-fahrt-annehmen** — 48-Stunden-Frist korrigiert (kurzfristige Fahrten deutlich kürzer).
- **fahrer-zuweisen** — abwesende Fahrer ausgegraut + Rückfrage „Ausserhalb der Verfügbarkeit".
- **Querschnitt** — „oben im Menü" → „links im Menü" (die Navigation ist eine linke Seitenleiste).

Bereits korrekte Artikel (fahrer-verfuegbarkeit, admin-benutzer, admin-tarife, serie-anlegen, abrechnung, dispatch-board, app-uebersicht, faq, kontakt) blieben inhaltlich unverändert.

## Verifikation
- Typecheck ✅ · Lint ✅ · **1068 Tests** ✅ · `next build` ✅ (Help-Seiten `/help`, `/help/[slug]`, `/hilfe` kompilieren)

Offen (nur wo neue Screenshots nötig): `TODO(content)` in fahrt-erfassen (Screenshot der 3-Schritt-Erfassung).

🤖 Generated with [Claude Code](https://claude.com/claude-code)