### PR TITLE
feat(mail): Sandbox-Guard gegen versehentlichen Versand an echte Fahrer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,26 @@ MAIL_FROM="Dispo Krankentransport <dispo-noreply@gmail.com>"
 DISPATCH_NOTIFICATION_EMAIL=dispatch@example.com
 
 # =============================================================================
+# Mail sandbox mode (see docs/guides/mail-testing.md)
+# =============================================================================
+# Controls whether real e-mails are delivered. FAIL-SAFE: if MAIL_MODE is unset
+# or invalid, the app NEVER sends to real recipients — it redirects (when
+# MAIL_REDIRECT_TO is set) or only logs. Set MAIL_MODE=live in Production ONLY
+# once you truly want to deliver to real drivers/patients.
+#   live     -> normal delivery to the real recipients
+#   redirect -> build + send as normal, but reroute ALL recipients to
+#               MAIL_REDIRECT_TO; subject gets a "[TEST → original@x]" prefix
+#   log      -> no send at all; only a mail_log row + server console line
+MAIL_MODE=
+# Target inbox for redirect mode (e.g. your Gmail). REQUIRED for redirect.
+# Tip: use a plus-alias per test driver, e.g. christian.stebler+fahrer1@gmail.com
+MAIL_REDIRECT_TO=
+# Optional: comma-separated addresses and/or @domain entries that are delivered
+# normally even in redirect mode (e.g. pilot drivers). Case-insensitive.
+# Example: MAIL_ALLOWLIST=pilot@example.ch,@pilot-fahrer.ch
+MAIL_ALLOWLIST=
+
+# =============================================================================
 # Cron Job Authentication (required for acceptance escalation)
 # =============================================================================
 CRON_SECRET=your-cron-secret-here

--- a/docs/guides/mail-testing.md
+++ b/docs/guides/mail-testing.md
@@ -1,0 +1,96 @@
+# Mail-Sandbox: sicheres End-zu-End-Testen
+
+Beim Testen dürfen **keine** E-Mails an echte (aus dem Altsystem importierte)
+Fahrer oder Patienten gehen. Dafür gibt es einen zentralen **Mail-Sandbox-Guard**:
+jeder Versand läuft über `sendGuardedMail` (`src/lib/mail/send.ts`), das anhand
+der Umgebungsvariable `MAIL_MODE` entscheidet, ob und an wen zugestellt wird.
+
+> Der rohe Gmail-Transport (`src/lib/mail/transport.ts`) ist `server-only` und
+> wird ausschließlich intern von `send.ts` verwendet. Neue Sender **müssen**
+> `sendGuardedMail` benutzen — direkt am Guard vorbei zu senden ist nicht möglich.
+
+## Die drei Modi
+
+| `MAIL_MODE` | Verhalten |
+|-------------|-----------|
+| `live`      | Normalversand an die echten Empfänger. |
+| `redirect`  | Mail wird vollständig normal aufgebaut und via Gmail versendet, aber **alle** Empfänger (to/cc/bcc) werden durch `MAIL_REDIRECT_TO` ersetzt. Der Betreff bekommt das Präfix `[TEST → original@x]`. cc/bcc werden ins `to` gefaltet, damit nie versehentlich eine echte Person in Kopie steht. |
+| `log`       | **Kein** Versand. Es wird nur ein `mail_log`-Eintrag geschrieben und eine server-seitige Konsolenzeile ausgegeben (nur Empfänger/Template/Betreff — **kein** Mail-Body mit PII). |
+
+### Fail-safe-Default (wichtig)
+
+Der Guard sendet **niemals** versehentlich an echte Empfänger:
+
+- `MAIL_MODE=live` → nur bei **explizit** gesetztem `live`.
+- `MAIL_MODE` nicht gesetzt **oder** ungültig →
+  - `redirect`, falls `MAIL_REDIRECT_TO` gesetzt ist,
+  - sonst `log`.
+- `MAIL_MODE=redirect` **ohne** `MAIL_REDIRECT_TO` → degradiert zu `log`.
+
+Kurz: Ohne bewusste Konfiguration geht **nichts** an echte Adressen raus.
+
+## Allowlist (Pilot-Fahrer)
+
+`MAIL_ALLOWLIST` ist optional und enthält kommaseparierte Einträge, die auch im
+`redirect`-Modus **normal** beliefert werden (z. B. später einzelne Pilot-Fahrer).
+Zwei Formen, case-insensitive:
+
+- **Ganze Adresse**: `pilot@example.ch`
+- **Ganze Domain**: `@pilot-fahrer.ch` (matcht jede Adresse dieser Domain)
+
+Beispiel:
+
+```
+MAIL_MODE=redirect
+MAIL_REDIRECT_TO=christian.stebler+fahrdienst@gmail.com
+MAIL_ALLOWLIST=pilot@example.ch,@pilot-fahrer.ch
+```
+
+Bei gemischten Empfängern gehen die allowlisteten Adressen echt raus, alle
+übrigen an `MAIL_REDIRECT_TO`.
+
+## Test-Fahrer-Trick (Gmail Plus-Alias)
+
+Gmail liefert alle Adressen der Form `name+beliebig@gmail.com` in dieselbe
+Inbox. So kann man je Test-Fahrer eine eigene, unterscheidbare Adresse
+hinterlegen, ohne echte Postfächer:
+
+- `christian.stebler+fahrer1@gmail.com`
+- `christian.stebler+fahrer2@gmail.com`
+
+Alle landen bei `christian.stebler@gmail.com`. Ideal, um den kompletten
+Zuweisungs-/Bestätigungs-Flow durchzuspielen.
+
+## `mail_log`
+
+Im `redirect`/`log`-Modus hält der Log-Eintrag den **Original-Empfänger** und
+den **effektiven Modus** fest (ohne Schema-Migration, als Vermerk im bestehenden
+`recipient`-Feld):
+
+| Modus     | `mail_log.recipient`                         | `mail_log.status` |
+|-----------|----------------------------------------------|-------------------|
+| live      | `driver@old.ch`                              | `sent`            |
+| redirect  | `driver@old.ch → test@inbox.ch [redirect]`   | `sent`            |
+| redirect + allowlist | `pilot@example.ch [allowlist]`    | `sent`            |
+| log       | `driver@old.ch [log]`                        | `logged`          |
+
+Das Feld führt immer mit dem ursprünglich beabsichtigten Empfänger, gefolgt vom
+Modus-Tag in eckigen Klammern.
+
+## Empfehlung für Vercel
+
+| Environment          | Empfehlung |
+|----------------------|-----------|
+| **Production**       | `MAIL_MODE` **erst** auf `live` setzen, wenn wirklich live gegangen wird. Vorher `redirect` (mit `MAIL_REDIRECT_TO`) oder gar nichts. |
+| **Preview / Dev**    | **Nichts** setzen. Der Fail-safe-Default (`log`, bzw. `redirect` falls jemand `MAIL_REDIRECT_TO` gesetzt hat) verhindert jeden echten Versand. |
+| **Lokal (`.env`)**   | Für E2E-Tests `MAIL_MODE=redirect` + `MAIL_REDIRECT_TO=deine+alias@gmail.com`. |
+
+> Merksatz: Solange in Production `MAIL_MODE` nicht explizit auf `live` steht,
+> erreicht **keine** Mail einen echten Fahrer.
+
+## Was passiert, wenn Christian nichts setzt?
+
+- **Production ohne `MAIL_MODE`**: Fail-safe → `log` (kein Versand), bzw.
+  `redirect`, falls `MAIL_REDIRECT_TO` gesetzt wurde. Nie `live`.
+- **Preview/Dev ohne alles**: `log` — sichtbar in `mail_log` und Server-Logs,
+  aber niemand bekommt Mail.

--- a/src/lib/mail/__tests__/guard.test.ts
+++ b/src/lib/mail/__tests__/guard.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest"
+import {
+  resolveMailMode,
+  parseAllowlist,
+  matchesAllowlist,
+  formatRecipientList,
+  planGuardedMail,
+  type GuardEnv,
+} from "../guard"
+
+// ---------------------------------------------------------------------------
+// resolveMailMode — fail-safe defaults
+// ---------------------------------------------------------------------------
+
+describe("resolveMailMode", () => {
+  it("returns live ONLY for an explicit MAIL_MODE=live", () => {
+    expect(resolveMailMode({ MAIL_MODE: "live" })).toBe("live")
+    expect(resolveMailMode({ MAIL_MODE: "LIVE" })).toBe("live")
+    expect(resolveMailMode({ MAIL_MODE: "  live  " })).toBe("live")
+  })
+
+  it("honours an explicit log mode", () => {
+    expect(resolveMailMode({ MAIL_MODE: "log" })).toBe("log")
+  })
+
+  it("honours redirect when a target is set", () => {
+    expect(
+      resolveMailMode({ MAIL_MODE: "redirect", MAIL_REDIRECT_TO: "t@x.ch" })
+    ).toBe("redirect")
+  })
+
+  it("degrades redirect to log when no target is set", () => {
+    expect(resolveMailMode({ MAIL_MODE: "redirect" })).toBe("log")
+    expect(
+      resolveMailMode({ MAIL_MODE: "redirect", MAIL_REDIRECT_TO: "  " })
+    ).toBe("log")
+  })
+
+  it("falls back to redirect when unset but a target exists", () => {
+    expect(resolveMailMode({ MAIL_REDIRECT_TO: "t@x.ch" })).toBe("redirect")
+  })
+
+  it("falls back to log when unset and no target exists", () => {
+    expect(resolveMailMode({})).toBe("log")
+  })
+
+  it("never defaults to live for an invalid value", () => {
+    expect(resolveMailMode({ MAIL_MODE: "nonsense" })).toBe("log")
+    expect(
+      resolveMailMode({ MAIL_MODE: "nonsense", MAIL_REDIRECT_TO: "t@x.ch" })
+    ).toBe("redirect")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Allowlist parsing + matching
+// ---------------------------------------------------------------------------
+
+describe("parseAllowlist", () => {
+  it("splits, trims, lower-cases and drops empties", () => {
+    expect(parseAllowlist(" A@B.ch , @Pilot.CH ,, ")).toEqual([
+      "a@b.ch",
+      "@pilot.ch",
+    ])
+  })
+
+  it("returns an empty list for undefined/empty", () => {
+    expect(parseAllowlist(undefined)).toEqual([])
+    expect(parseAllowlist("")).toEqual([])
+  })
+})
+
+describe("matchesAllowlist", () => {
+  const list = parseAllowlist("pilot@example.ch, @fahrer.ch")
+
+  it("matches a full address case-insensitively", () => {
+    expect(matchesAllowlist("Pilot@Example.CH", list)).toBe(true)
+    expect(matchesAllowlist("other@example.ch", list)).toBe(false)
+  })
+
+  it("matches any address on an @domain entry, case-insensitively", () => {
+    expect(matchesAllowlist("anna@fahrer.ch", list)).toBe(true)
+    expect(matchesAllowlist("ANNA@FAHRER.CH", list)).toBe(true)
+    expect(matchesAllowlist("anna@notfahrer.ch", list)).toBe(false)
+  })
+
+  it("returns false for an empty allowlist or empty email", () => {
+    expect(matchesAllowlist("a@b.ch", [])).toBe(false)
+    expect(matchesAllowlist("", list)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatRecipientList
+// ---------------------------------------------------------------------------
+
+describe("formatRecipientList", () => {
+  it("lists up to three recipients in full", () => {
+    expect(formatRecipientList(["a@x.ch", "b@x.ch", "c@x.ch"])).toBe(
+      "a@x.ch, b@x.ch, c@x.ch"
+    )
+  })
+
+  it("collapses four or more into first + count", () => {
+    expect(
+      formatRecipientList(["a@x.ch", "b@x.ch", "c@x.ch", "d@x.ch"])
+    ).toBe("a@x.ch +3 weitere")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// planGuardedMail
+// ---------------------------------------------------------------------------
+
+describe("planGuardedMail", () => {
+  const base = { to: "driver@old.ch", subject: "Neuer Auftrag" }
+
+  it("passes mail through untouched in live mode", () => {
+    const plan = planGuardedMail(base, { MAIL_MODE: "live" })
+    expect(plan.mode).toBe("live")
+    expect(plan.send).toBe(true)
+    expect(plan.to).toBe("driver@old.ch")
+    expect(plan.subject).toBe("Neuer Auftrag")
+    expect(plan.logStatus).toBe("sent")
+    expect(plan.auditLabel).toBe("driver@old.ch")
+    expect(plan.effectiveRecipients).toEqual(["driver@old.ch"])
+  })
+
+  it("does not send in log mode and reports the original recipient", () => {
+    const plan = planGuardedMail(base, { MAIL_MODE: "log" })
+    expect(plan.mode).toBe("log")
+    expect(plan.send).toBe(false)
+    expect(plan.logStatus).toBe("logged")
+    expect(plan.effectiveRecipients).toEqual([])
+    expect(plan.auditLabel).toBe("driver@old.ch [log]")
+    expect(plan.originalRecipients).toEqual(["driver@old.ch"])
+  })
+
+  it("rewrites recipient and prefixes the subject in redirect mode", () => {
+    const env: GuardEnv = {
+      MAIL_MODE: "redirect",
+      MAIL_REDIRECT_TO: "test@inbox.ch",
+    }
+    const plan = planGuardedMail(base, env)
+    expect(plan.mode).toBe("redirect")
+    expect(plan.send).toBe(true)
+    expect(plan.to).toEqual(["test@inbox.ch"])
+    expect(plan.subject).toBe("[TEST → driver@old.ch] Neuer Auftrag")
+    expect(plan.logStatus).toBe("sent")
+    expect(plan.auditLabel).toBe("driver@old.ch → test@inbox.ch [redirect]")
+  })
+
+  it("folds cc/bcc into the redirect target and lists all originals in the prefix", () => {
+    const env: GuardEnv = {
+      MAIL_MODE: "redirect",
+      MAIL_REDIRECT_TO: "test@inbox.ch",
+    }
+    const plan = planGuardedMail(
+      {
+        to: "a@old.ch",
+        cc: "b@old.ch",
+        bcc: ["c@old.ch", "d@old.ch"],
+        subject: "Hallo",
+      },
+      env
+    )
+    expect(plan.to).toEqual(["test@inbox.ch"])
+    expect(plan.cc).toBeUndefined()
+    expect(plan.bcc).toBeUndefined()
+    // Four originals -> first + count in the subject prefix.
+    expect(plan.subject).toBe("[TEST → a@old.ch +3 weitere] Hallo")
+    expect(plan.originalRecipients).toEqual([
+      "a@old.ch",
+      "b@old.ch",
+      "c@old.ch",
+      "d@old.ch",
+    ])
+  })
+
+  it("delivers allowlisted recipients normally even in redirect mode", () => {
+    const env: GuardEnv = {
+      MAIL_MODE: "redirect",
+      MAIL_REDIRECT_TO: "test@inbox.ch",
+      MAIL_ALLOWLIST: "pilot@fahrer.ch",
+    }
+    const plan = planGuardedMail(
+      { to: "pilot@fahrer.ch", subject: "Auftrag" },
+      env
+    )
+    // Fully allowlisted -> no redirect, no subject prefix.
+    expect(plan.to).toEqual(["pilot@fahrer.ch"])
+    expect(plan.subject).toBe("Auftrag")
+    expect(plan.auditLabel).toBe("pilot@fahrer.ch [allowlist]")
+  })
+
+  it("splits allowlisted (passthrough) and non-allowlisted (redirect) recipients", () => {
+    const env: GuardEnv = {
+      MAIL_MODE: "redirect",
+      MAIL_REDIRECT_TO: "test@inbox.ch",
+      MAIL_ALLOWLIST: "@fahrer.ch",
+    }
+    const plan = planGuardedMail(
+      { to: ["pilot@fahrer.ch", "legacy@old.ch"], subject: "Auftrag" },
+      env
+    )
+    expect(plan.to).toEqual(["pilot@fahrer.ch", "test@inbox.ch"])
+    // Only the redirected (non-allowlisted) address appears in the prefix.
+    expect(plan.subject).toBe("[TEST → legacy@old.ch] Auftrag")
+  })
+
+  it("de-duplicates repeated recipients case-insensitively", () => {
+    const plan = planGuardedMail(
+      { to: "Driver@Old.ch", cc: "driver@old.ch", subject: "x" },
+      { MAIL_MODE: "log" }
+    )
+    expect(plan.originalRecipients).toEqual(["Driver@Old.ch"])
+  })
+})

--- a/src/lib/mail/__tests__/receipt-mail.test.ts
+++ b/src/lib/mail/__tests__/receipt-mail.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, vi } from "vitest"
+
+// receipt-mail.ts pulls in the guarded sender, which imports the server-only
+// Gmail transport. Mock the transport so this pure-render test does not drag
+// `server-only` (which throws under vitest) into the module graph.
+vi.mock("../transport", () => ({
+  mailTransport: { sendMail: vi.fn() },
+}))
+
 import { renderReceiptMail, type ReceiptMailData } from "../receipt-mail"
 
 const base: ReceiptMailData = {

--- a/src/lib/mail/__tests__/send-driver-confirmation.test.ts
+++ b/src/lib/mail/__tests__/send-driver-confirmation.test.ts
@@ -1,10 +1,23 @@
-import { describe, it, expect, vi, beforeEach, type Mock } from "vitest"
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from "vitest"
 import type { OrderSheetData } from "../load-order-sheet-data"
 
 // ---------------------------------------------------------------------------
 // Module mocks (hoisted by vitest)
 // ---------------------------------------------------------------------------
 
+// The sender now sends via `../send` (sendGuardedMail), which wraps the mocked
+// transport. We keep mocking the transport (not the guard) so this test still
+// exercises the real guard logic — pinned to live mode so behaviour matches
+// production delivery. `../transport` also imports `server-only`, which throws
+// under vitest; mocking it keeps that module out of the test graph entirely.
 vi.mock("../transport", () => ({
   mailTransport: { sendMail: vi.fn() },
 }))
@@ -145,8 +158,21 @@ const sendMailMock = mailTransport.sendMail as unknown as Mock
 const loadDataMock = loadOrderSheetData as unknown as Mock
 const createAdminClientMock = createAdminClient as unknown as Mock
 
+const ORIGINAL_MAIL_MODE = process.env.MAIL_MODE
+
 beforeEach(() => {
   vi.clearAllMocks()
+  // Pin to live mode so the guard delivers to the real recipient, matching
+  // the production delivery path this test asserts on.
+  process.env.MAIL_MODE = "live"
+})
+
+afterEach(() => {
+  if (ORIGINAL_MAIL_MODE === undefined) {
+    delete process.env.MAIL_MODE
+  } else {
+    process.env.MAIL_MODE = ORIGINAL_MAIL_MODE
+  }
 })
 
 // ---------------------------------------------------------------------------

--- a/src/lib/mail/__tests__/send.test.ts
+++ b/src/lib/mail/__tests__/send.test.ts
@@ -1,0 +1,126 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from "vitest"
+
+// Mock the transport so no real Gmail send happens and `server-only`
+// (imported by ../transport) never enters the test module graph.
+vi.mock("../transport", () => ({
+  mailTransport: { sendMail: vi.fn() },
+}))
+
+import { sendGuardedMail } from "../send"
+import { mailTransport } from "../transport"
+
+const sendMailMock = mailTransport.sendMail as unknown as Mock
+
+const ORIGINAL_ENV = {
+  MAIL_MODE: process.env.MAIL_MODE,
+  MAIL_REDIRECT_TO: process.env.MAIL_REDIRECT_TO,
+  MAIL_ALLOWLIST: process.env.MAIL_ALLOWLIST,
+}
+
+function resetEnv(): void {
+  delete process.env.MAIL_MODE
+  delete process.env.MAIL_REDIRECT_TO
+  delete process.env.MAIL_ALLOWLIST
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  sendMailMock.mockResolvedValue({ messageId: "1" })
+  resetEnv()
+})
+
+afterEach(() => {
+  resetEnv()
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value !== undefined) process.env[key] = value
+  }
+})
+
+describe("sendGuardedMail", () => {
+  it("delivers to the real recipient in live mode", async () => {
+    process.env.MAIL_MODE = "live"
+
+    const result = await sendGuardedMail({
+      to: "driver@old.ch",
+      subject: "Auftrag",
+      html: "<p>secret PII</p>",
+      template: "order-sheet",
+    })
+
+    expect(sendMailMock).toHaveBeenCalledTimes(1)
+    expect(sendMailMock.mock.calls[0]?.[0]).toMatchObject({
+      to: "driver@old.ch",
+      subject: "Auftrag",
+    })
+    expect(result.sent).toBe(true)
+    expect(result.logStatus).toBe("sent")
+    expect(result.auditLabel).toBe("driver@old.ch")
+  })
+
+  it("redirects the recipient and prefixes the subject in redirect mode", async () => {
+    process.env.MAIL_MODE = "redirect"
+    process.env.MAIL_REDIRECT_TO = "test@inbox.ch"
+
+    const result = await sendGuardedMail({
+      to: "driver@old.ch",
+      subject: "Auftrag",
+      html: "<p>x</p>",
+    })
+
+    expect(sendMailMock).toHaveBeenCalledTimes(1)
+    const arg = sendMailMock.mock.calls[0]?.[0]
+    expect(arg?.to).toEqual(["test@inbox.ch"])
+    expect(arg?.subject).toBe("[TEST → driver@old.ch] Auftrag")
+    expect(result.logStatus).toBe("sent")
+    expect(result.auditLabel).toBe("driver@old.ch → test@inbox.ch [redirect]")
+  })
+
+  it("does NOT hand anything to the transport in log mode", async () => {
+    process.env.MAIL_MODE = "log"
+
+    const result = await sendGuardedMail({
+      to: "driver@old.ch",
+      subject: "Auftrag",
+      html: "<p>secret PII</p>",
+      template: "order-sheet",
+    })
+
+    expect(sendMailMock).not.toHaveBeenCalled()
+    expect(result.sent).toBe(false)
+    expect(result.logStatus).toBe("logged")
+    expect(result.auditLabel).toBe("driver@old.ch [log]")
+  })
+
+  it("fails safe to log mode when nothing is configured", async () => {
+    const result = await sendGuardedMail({
+      to: "driver@old.ch",
+      subject: "Auftrag",
+      html: "<p>x</p>",
+    })
+
+    expect(sendMailMock).not.toHaveBeenCalled()
+    expect(result.mode).toBe("log")
+  })
+
+  it("strips the internal template field before handing off to nodemailer", async () => {
+    process.env.MAIL_MODE = "live"
+
+    await sendGuardedMail({
+      to: "driver@old.ch",
+      subject: "Auftrag",
+      html: "<p>x</p>",
+      template: "order-sheet",
+    })
+
+    const arg = sendMailMock.mock.calls[0]?.[0] ?? {}
+    expect("template" in arg).toBe(false)
+  })
+})

--- a/src/lib/mail/guard.ts
+++ b/src/lib/mail/guard.ts
@@ -1,0 +1,221 @@
+/**
+ * Mail sandbox guard — PURE mode-resolution and recipient-rewriting logic.
+ *
+ * This module contains NO I/O (no nodemailer, no Supabase, no process.env
+ * access at module scope). All environment input is passed in explicitly so
+ * every branch is unit-testable. The actual send lives in `./send.ts`, which
+ * wraps `mailTransport` and consumes the plan produced here.
+ *
+ * Purpose: during end-to-end testing we must NEVER deliver mail to the real
+ * (legacy-imported) drivers. The guard enforces a fail-safe default — without
+ * an explicit `MAIL_MODE=live`, mail is either redirected to a test inbox or
+ * only logged. See docs/guides/mail-testing.md.
+ */
+
+export type MailMode = "live" | "redirect" | "log"
+
+/** The subset of environment variables the guard reads. */
+export interface GuardEnv {
+  MAIL_MODE?: string
+  MAIL_REDIRECT_TO?: string
+  MAIL_ALLOWLIST?: string
+}
+
+/** Recipient fields as accepted by nodemailer (single or multiple). */
+export interface RecipientFields {
+  to?: string | string[]
+  cc?: string | string[]
+  bcc?: string | string[]
+  subject: string
+}
+
+export interface GuardedMailPlan {
+  mode: MailMode
+  /** Whether the mail should actually be handed to the transport. */
+  send: boolean
+  /** Effective recipient fields to pass to nodemailer (only relevant if send). */
+  to?: string | string[]
+  cc?: string | string[]
+  bcc?: string | string[]
+  subject: string
+  /** All distinct originally-intended recipients (to + cc + bcc). */
+  originalRecipients: string[]
+  /** Who the mail is actually delivered to (empty in log mode). */
+  effectiveRecipients: string[]
+  /**
+   * Audit label for `mail_log.recipient`. Always LEADS with the original
+   * recipient(s), followed by a bracketed mode tag so the effective mode is
+   * captured without a schema migration (e.g. "a@old.ch → test@x [redirect]").
+   */
+  auditLabel: string
+  /** Suggested value for `mail_log.status`. */
+  logStatus: "sent" | "logged"
+}
+
+/**
+ * Resolve the effective mail mode.
+ *
+ * Fail-safe contract: the result is NEVER `live` unless `MAIL_MODE` is
+ * explicitly `live`. Anything unset or invalid degrades to `redirect` (when a
+ * redirect target exists) or `log`. `redirect` without a target also degrades
+ * to `log` — we never send to real recipients by accident.
+ */
+export function resolveMailMode(env: GuardEnv): MailMode {
+  const raw = (env.MAIL_MODE ?? "").trim().toLowerCase()
+  const hasRedirectTarget = (env.MAIL_REDIRECT_TO ?? "").trim().length > 0
+
+  if (raw === "live") return "live"
+  if (raw === "log") return "log"
+  if (raw === "redirect") return hasRedirectTarget ? "redirect" : "log"
+
+  // Unset or invalid value — fail-safe, never live.
+  return hasRedirectTarget ? "redirect" : "log"
+}
+
+/**
+ * Parse a comma-separated allowlist into normalised (trimmed, lower-cased)
+ * entries. Entries may be full addresses ("a@b.ch") or domain entries ("@b.ch").
+ */
+export function parseAllowlist(raw: string | undefined): string[] {
+  if (!raw) return []
+  return raw
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.length > 0)
+}
+
+/**
+ * Case-insensitive allowlist match. An entry starting with "@" matches any
+ * address on that domain; otherwise the whole address must match exactly.
+ */
+export function matchesAllowlist(email: string, allowlist: string[]): boolean {
+  const target = email.trim().toLowerCase()
+  if (!target) return false
+
+  for (const entry of allowlist) {
+    if (entry.startsWith("@")) {
+      if (target.endsWith(entry)) return true
+    } else if (target === entry) {
+      return true
+    }
+  }
+  return false
+}
+
+/** Flatten a single-or-array recipient field into a plain string array. */
+function toArray(value: string | string[] | undefined): string[] {
+  if (!value) return []
+  return Array.isArray(value) ? value : [value]
+}
+
+/** De-duplicate case-insensitively while preserving first-seen order/casing. */
+function dedupe(list: string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const item of list) {
+    const trimmed = item.trim()
+    const key = trimmed.toLowerCase()
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    out.push(trimmed)
+  }
+  return out
+}
+
+/**
+ * Format a recipient list for human-readable subject/audit text. Up to three
+ * are listed in full; beyond that the first is shown with a "+N weitere" count.
+ */
+export function formatRecipientList(list: string[]): string {
+  if (list.length === 0) return "(keine)"
+  if (list.length <= 3) return list.join(", ")
+  const [first] = list
+  return `${first ?? ""} +${list.length - 1} weitere`
+}
+
+/**
+ * Build the full send plan for a mail given the current environment. Pure.
+ */
+export function planGuardedMail(
+  fields: RecipientFields,
+  env: GuardEnv
+): GuardedMailPlan {
+  const mode = resolveMailMode(env)
+  const originalRecipients = dedupe([
+    ...toArray(fields.to),
+    ...toArray(fields.cc),
+    ...toArray(fields.bcc),
+  ])
+
+  if (mode === "live") {
+    return {
+      mode,
+      send: true,
+      to: fields.to,
+      cc: fields.cc,
+      bcc: fields.bcc,
+      subject: fields.subject,
+      originalRecipients,
+      effectiveRecipients: originalRecipients,
+      auditLabel: formatRecipientList(originalRecipients),
+      logStatus: "sent",
+    }
+  }
+
+  if (mode === "log") {
+    return {
+      mode,
+      send: false,
+      to: fields.to,
+      cc: fields.cc,
+      bcc: fields.bcc,
+      subject: fields.subject,
+      originalRecipients,
+      effectiveRecipients: [],
+      auditLabel: `${formatRecipientList(originalRecipients)} [log]`,
+      logStatus: "logged",
+    }
+  }
+
+  // --- redirect mode --------------------------------------------------------
+  // resolveMailMode guarantees a non-empty redirect target here.
+  const redirectTarget = (env.MAIL_REDIRECT_TO ?? "").trim()
+  const allowlist = parseAllowlist(env.MAIL_ALLOWLIST)
+  const passthrough = originalRecipients.filter((email) =>
+    matchesAllowlist(email, allowlist)
+  )
+  const redirected = originalRecipients.filter(
+    (email) => !matchesAllowlist(email, allowlist)
+  )
+
+  // Allowlisted recipients are still delivered; everything else collapses onto
+  // the single redirect target. cc/bcc are folded into `to` so no real person
+  // is ever cc'd by accident.
+  const effectiveTo = dedupe([
+    ...passthrough,
+    ...(redirected.length > 0 ? [redirectTarget] : []),
+  ])
+
+  const subject =
+    redirected.length > 0
+      ? `[TEST → ${formatRecipientList(redirected)}] ${fields.subject}`
+      : fields.subject
+
+  const auditLabel =
+    redirected.length > 0
+      ? `${formatRecipientList(originalRecipients)} → ${redirectTarget} [redirect]`
+      : `${formatRecipientList(originalRecipients)} [allowlist]`
+
+  return {
+    mode,
+    send: true,
+    to: effectiveTo,
+    cc: undefined,
+    bcc: undefined,
+    subject,
+    originalRecipients,
+    effectiveRecipients: effectiveTo,
+    auditLabel,
+    logStatus: "sent",
+  }
+}

--- a/src/lib/mail/receipt-mail.ts
+++ b/src/lib/mail/receipt-mail.ts
@@ -1,5 +1,5 @@
 import { createAdminClient } from "@/lib/supabase/admin"
-import { mailTransport } from "@/lib/mail/transport"
+import { sendGuardedMail } from "@/lib/mail/send"
 import { escapeHtml } from "@/lib/mail/utils"
 
 // Storage bucket holding the immutable receipt PDFs (private).
@@ -184,13 +184,16 @@ export async function sendReceiptMail(
     orgName: org?.org_name ?? "Fahrdienst",
   })
 
-  // 5. Send with the PDF attached (never a link).
+  // 5. Send with the PDF attached (never a link), through the sandbox guard.
+  let guardAuditLabel = recipientEmail
+  let guardStatus: "sent" | "logged" = "sent"
   try {
-    await mailTransport.sendMail({
+    const guard = await sendGuardedMail({
       from: process.env.MAIL_FROM ?? process.env.GMAIL_USER,
       to: recipientEmail,
       subject,
       html,
+      template: "receipt",
       attachments: [
         {
           filename: `${receipt.receipt_number}.pdf`,
@@ -199,6 +202,8 @@ export async function sendReceiptMail(
         },
       ],
     })
+    guardAuditLabel = guard.auditLabel
+    guardStatus = guard.logStatus
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unbekannter Fehler"
     console.error("[receipt-mail] send failed:", message)
@@ -209,7 +214,7 @@ export async function sendReceiptMail(
     }
   }
 
-  await logReceiptMail(supabase, recipientEmail, "sent", null)
+  await logReceiptMail(supabase, guardAuditLabel, guardStatus, null)
   return { ok: true, recipient: recipientEmail }
 }
 
@@ -221,7 +226,7 @@ export async function sendReceiptMail(
 async function logReceiptMail(
   supabase: ReturnType<typeof createAdminClient>,
   recipient: string,
-  status: "sent" | "failed",
+  status: "sent" | "failed" | "logged",
   error: string | null
 ): Promise<void> {
   try {

--- a/src/lib/mail/send-absence-decision.ts
+++ b/src/lib/mail/send-absence-decision.ts
@@ -1,5 +1,5 @@
 import { createAdminClient } from "@/lib/supabase/admin"
-import { mailTransport } from "@/lib/mail/transport"
+import { sendGuardedMail } from "@/lib/mail/send"
 import { absenceDecisionEmail } from "@/lib/mail/templates/absence-decision"
 import type { AbsenceType } from "@/lib/absences/status-machine"
 
@@ -85,15 +85,23 @@ export async function sendAbsenceDecisionNotification(
     note: absence.decision_note,
   })
 
-  // 4. Send. A transport failure is logged but never thrown.
+  // 4. Send (through the sandbox guard). A transport failure is logged but
+  //    never thrown.
   try {
-    await mailTransport.sendMail({
+    const guard = await sendGuardedMail({
       from: process.env.MAIL_FROM ?? process.env.GMAIL_USER,
       to: recipientEmail,
       subject,
       html,
+      template: "absence-decision",
     })
-    await logMail(supabase, absence.driver_id, recipientEmail, "sent", null)
+    await logMail(
+      supabase,
+      absence.driver_id,
+      guard.auditLabel,
+      guard.logStatus,
+      null
+    )
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error"
     console.error("Absence decision mail: send failed", message)
@@ -106,7 +114,7 @@ async function logMail(
   supabase: ReturnType<typeof createAdminClient>,
   driverId: string,
   recipient: string,
-  status: "sent" | "failed",
+  status: "sent" | "failed" | "logged",
   error: string | null
 ): Promise<void> {
   try {

--- a/src/lib/mail/send-driver-confirmation.ts
+++ b/src/lib/mail/send-driver-confirmation.ts
@@ -1,7 +1,7 @@
 import { createAdminClient } from "@/lib/supabase/admin"
 import { driverConfirmationEmail } from "@/lib/mail/templates/driver-confirmation"
 import { buildRideIcs, type RideIcsInput } from "@/lib/mail/ics"
-import { mailTransport } from "@/lib/mail/transport"
+import { sendGuardedMail } from "@/lib/mail/send"
 import { loadOrderSheetData } from "@/lib/mail/load-order-sheet-data"
 import type { OrderSheetData } from "@/lib/mail/load-order-sheet-data"
 
@@ -109,13 +109,14 @@ export async function sendDriverConfirmation(
   const { subject, html } = driverConfirmationEmail(orderData)
   const ics = buildRideIcs(toIcsInput(orderData))
 
-  // 4. Send
+  // 4. Send (through the sandbox guard)
   try {
-    await mailTransport.sendMail({
+    const guard = await sendGuardedMail({
       from: process.env.MAIL_FROM ?? process.env.GMAIL_USER,
       to: recipientEmail,
       subject,
       html,
+      template: TEMPLATE,
       attachments: [
         {
           filename: "fahrt.ics",
@@ -129,8 +130,8 @@ export async function sendDriverConfirmation(
       ride_id: rideId,
       driver_id: driverId,
       template: TEMPLATE,
-      recipient: recipientEmail,
-      status: "sent",
+      recipient: guard.auditLabel,
+      status: guard.logStatus,
     })
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : "Unknown error"

--- a/src/lib/mail/send-driver-notification.ts
+++ b/src/lib/mail/send-driver-notification.ts
@@ -1,7 +1,7 @@
 import { createAdminClient } from "@/lib/supabase/admin"
 import { createAssignmentToken } from "@/lib/mail/tokens"
 import { assembleOrderSheet } from "@/lib/mail/templates/order-sheet"
-import { mailTransport } from "@/lib/mail/transport"
+import { sendGuardedMail } from "@/lib/mail/send"
 import { formatDate, formatTime } from "@/lib/mail/utils"
 import { loadOrderSheetData } from "@/lib/mail/load-order-sheet-data"
 import type { OrderSheetData } from "@/lib/mail/load-order-sheet-data"
@@ -85,21 +85,22 @@ export async function sendDriverNotification(
   const html = assembleOrderSheet(orderData)
   const subject = `Neuer Auftrag \u2013 ${formatDate(orderData.date)}, ${formatTime(orderData.pickupTime)} Uhr`
 
-  // 5. Send email
+  // 5. Send email (through the sandbox guard)
   try {
-    await mailTransport.sendMail({
+    const guard = await sendGuardedMail({
       from: process.env.MAIL_FROM ?? process.env.GMAIL_USER,
       to: recipientEmail,
       subject,
       html,
+      template: "order-sheet",
     })
 
     await supabase.from("mail_log").insert({
       ride_id: rideId,
       driver_id: driverId,
       template: "order-sheet",
-      recipient: recipientEmail,
-      status: "sent",
+      recipient: guard.auditLabel,
+      status: guard.logStatus,
     })
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : "Unknown error"

--- a/src/lib/mail/send.ts
+++ b/src/lib/mail/send.ts
@@ -1,0 +1,95 @@
+import type Mail from "nodemailer/lib/mailer"
+import { mailTransport } from "@/lib/mail/transport"
+import { planGuardedMail, type MailMode } from "@/lib/mail/guard"
+
+/**
+ * Central, guarded mail entry point. EVERY outgoing mail must go through this
+ * wrapper — `mailTransport` is intentionally not used directly by senders any
+ * more, so no future sender can bypass the sandbox guard.
+ *
+ * The mode logic lives in the pure `./guard` module; this file only performs
+ * the side effects (transport send + console logging) based on the plan.
+ */
+
+export interface GuardedMailOptions {
+  from?: string
+  to?: string | string[]
+  cc?: string | string[]
+  bcc?: string | string[]
+  subject: string
+  html: string
+  text?: string
+  attachments?: Mail.Options["attachments"]
+  replyTo?: string
+  /**
+   * Optional template label. Used ONLY for the log-mode console line so the
+   * operator can tell which mail was suppressed. Never handed to nodemailer.
+   */
+  template?: string
+}
+
+export interface GuardedMailResult {
+  mode: MailMode
+  /** false only in `log` mode (nothing was handed to the transport). */
+  sent: boolean
+  originalRecipients: string[]
+  effectiveRecipients: string[]
+  /** Store in `mail_log.recipient` — leads with the original recipient(s). */
+  auditLabel: string
+  /** Store in `mail_log.status`. */
+  logStatus: "sent" | "logged"
+}
+
+/**
+ * Send a mail through the sandbox guard.
+ *
+ * - `live`:     delivered normally.
+ * - `redirect`: delivered to MAIL_REDIRECT_TO (allowlisted recipients still get
+ *               the real mail); subject is prefixed with the original audience.
+ * - `log`:      not sent at all; a metadata-only console line is emitted (no
+ *               HTML body / PII) and the caller writes a `mail_log` row.
+ *
+ * Throws only if the underlying transport throws in live/redirect mode, so
+ * existing fire-and-forget try/catch semantics in the senders are preserved.
+ */
+export async function sendGuardedMail(
+  options: GuardedMailOptions
+): Promise<GuardedMailResult> {
+  const { template, to, cc, bcc, subject, ...rest } = options
+
+  const plan = planGuardedMail(
+    { to, cc, bcc, subject },
+    {
+      MAIL_MODE: process.env.MAIL_MODE,
+      MAIL_REDIRECT_TO: process.env.MAIL_REDIRECT_TO,
+      MAIL_ALLOWLIST: process.env.MAIL_ALLOWLIST,
+    }
+  )
+
+  if (plan.send) {
+    await mailTransport.sendMail({
+      ...rest,
+      to: plan.to,
+      cc: plan.cc,
+      bcc: plan.bcc,
+      subject: plan.subject,
+    })
+  } else {
+    // log mode: metadata only. Deliberately NO html/text body (may carry PII).
+    console.info(
+      `[mail:guard] MAIL_MODE=log — send suppressed. ` +
+        `template=${template ?? "?"} ` +
+        `recipients=${plan.originalRecipients.join(", ") || "(none)"} ` +
+        `subject=${JSON.stringify(plan.subject)}`
+    )
+  }
+
+  return {
+    mode: plan.mode,
+    sent: plan.send,
+    originalRecipients: plan.originalRecipients,
+    effectiveRecipients: plan.effectiveRecipients,
+    auditLabel: plan.auditLabel,
+    logStatus: plan.logStatus,
+  }
+}

--- a/src/lib/mail/templates/dispatcher-escalation.ts
+++ b/src/lib/mail/templates/dispatcher-escalation.ts
@@ -1,5 +1,5 @@
 import { createAdminClient } from "@/lib/supabase/admin"
-import { mailTransport } from "@/lib/mail/transport"
+import { sendGuardedMail } from "@/lib/mail/send"
 import { escapeHtml, formatDate, formatTime } from "@/lib/mail/utils"
 import { getAppUrl } from "@/lib/acceptance/constants"
 
@@ -205,19 +205,20 @@ export async function sendDispatcherEscalation(
   })
 
   try {
-    await mailTransport.sendMail({
+    const guard = await sendGuardedMail({
       from: process.env.MAIL_FROM ?? process.env.GMAIL_USER,
       to: recipientEmail,
       subject,
       html,
+      template: "dispatcher-escalation",
     })
 
     await supabase.from("mail_log").insert({
       ride_id: rideId,
       driver_id: driverId,
       template: "dispatcher-escalation",
-      recipient: recipientEmail,
-      status: "sent",
+      recipient: guard.auditLabel,
+      status: guard.logStatus,
     })
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : "Unknown error"

--- a/src/lib/mail/templates/driver-reminder.ts
+++ b/src/lib/mail/templates/driver-reminder.ts
@@ -1,5 +1,5 @@
 import { createAdminClient } from "@/lib/supabase/admin"
-import { mailTransport } from "@/lib/mail/transport"
+import { sendGuardedMail } from "@/lib/mail/send"
 import { escapeHtml, formatDate, formatTime } from "@/lib/mail/utils"
 import { RIDE_DIRECTION_LABELS } from "@/lib/rides/constants"
 import { getAppUrl } from "@/lib/acceptance/constants"
@@ -215,19 +215,20 @@ export async function sendDriverReminder(
   })
 
   try {
-    await mailTransport.sendMail({
+    const guard = await sendGuardedMail({
       from: process.env.MAIL_FROM ?? process.env.GMAIL_USER,
       to: recipientEmail,
       subject,
       html,
+      template: `driver-reminder-${stage}`,
     })
 
     await supabase.from("mail_log").insert({
       ride_id: rideId,
       driver_id: driverId,
       template: `driver-reminder-${stage}`,
-      recipient: recipientEmail,
-      status: "sent",
+      recipient: guard.auditLabel,
+      status: guard.logStatus,
     })
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : "Unknown error"

--- a/src/lib/mail/transport.ts
+++ b/src/lib/mail/transport.ts
@@ -1,5 +1,14 @@
+// server-only: the Gmail transport must never be pulled into a client bundle.
+// It is reached exclusively through `./send.ts` (sendGuardedMail); senders no
+// longer import this module directly, so the sandbox guard cannot be bypassed.
+import "server-only"
 import nodemailer from "nodemailer"
 
+/**
+ * Low-level Gmail transport. INTERNAL — do not import outside `./send.ts`.
+ * All application mail goes through `sendGuardedMail` so the MAIL_MODE sandbox
+ * guard is always applied.
+ */
 export const mailTransport = nodemailer.createTransport({
   service: "gmail",
   auth: {


### PR DESCRIPTION
## Ziel

Beim End-zu-End-Testen dürfen **keine** E-Mails an echte, aus dem Altsystem importierte Fahrer (oder Patienten) gehen. Dieser PR führt einen zentralen **Mail-Sandbox-Guard** ein. Ansatz von Christian freigegeben.

## Umsetzung

- **`src/lib/mail/guard.ts`** (pure, ohne I/O): Modus-Auflösung + Empfänger-Rewriting, vollständig unit-getestet.
- **`src/lib/mail/send.ts`**: `sendGuardedMail(options)` als einziger Versand-Einstiegspunkt (Transport-Aufruf + Log-Konsolenzeile).
- **`src/lib/mail/transport.ts`**: `mailTransport` ist jetzt `server-only` und nur noch intern aus `send.ts` erreichbar → kein Sender kann am Guard vorbei.
- Alle Sender umgestellt: `send-driver-notification`, `send-driver-confirmation`, `send-absence-decision`, `receipt-mail`, `driver-reminder`, `dispatcher-escalation`.

### `MAIL_MODE`

| Modus | Verhalten |
|-------|-----------|
| `live` | Normalversand |
| `redirect` | Aufbau + Versand normal, aber alle Empfänger → `MAIL_REDIRECT_TO`; Betreff-Präfix `[TEST → original@x]`; cc/bcc ins `to` gefaltet |
| `log` | Kein Versand; nur `mail_log`-Eintrag + PII-freie Konsolenzeile |

**Fail-safe-Default:** ohne/ungültiges `MAIL_MODE` → `redirect` (falls `MAIL_REDIRECT_TO` gesetzt), sonst `log`. **Nie** default-live.

**`MAIL_ALLOWLIST`** (optional): kommaseparierte Adressen und/oder `@domain`-Einträge (case-insensitive), die auch im redirect-Modus normal beliefert werden — für spätere Pilot-Fahrer.

### mail_log ohne Migration

Original-Empfänger + effektiver Modus werden als Vermerk im bestehenden `recipient`-Feld festgehalten (z. B. `driver@old.ch → test@x [redirect]`), `status` wird `logged` im log-Modus. Keine Schema-Migration nötig.

## Doku

- `docs/guides/mail-testing.md` (drei Modi, Vercel-Empfehlung, Gmail-Plus-Alias-Trick)
- `.env.example` ergänzt

## Tests / Checks

- Typecheck: grün
- Lint: grün (nur bestehende, unbezogene Warnungen)
- Vitest: 1128/1128 grün (neu: `guard.test.ts` 21, `send.test.ts` 5)
- `next build`: grün — `server-only`-Transport landet in keinem Client-Bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)