### PR TITLE
feat(m15): Kontext-Filterung Fahrer-Panel + [Zuweisen]-Flow (#169)

### DIFF
--- a/src/actions/__tests__/assign-driver-with-return.test.ts
+++ b/src/actions/__tests__/assign-driver-with-return.test.ts
@@ -346,6 +346,60 @@ describe("assignDriverWithReturn", () => {
     expect(mockCreateTracking).not.toHaveBeenCalled()
   })
 
+  it("blocks a re-request to the SAME driver on a rejected leg when absent (SEC-M15-199-001)", async () => {
+    // rejectAssignment leaves driver_id in place, so re-requesting the same
+    // driver from an Abgelehnt card is the NORMAL case — the absence guard
+    // must fire even though the driver does not change.
+    store.rows.set(OUTBOUND, {
+      id: OUTBOUND,
+      status: "rejected",
+      driver_id: DRIVER,
+      date: "2026-08-01",
+      pickup_time: "09:00:00",
+      parent_ride_id: null,
+    })
+    mockGetDriverDayStatus.mockResolvedValue(statusAbsent())
+
+    const result = await assignDriverWithReturn(OUTBOUND, DRIVER, {
+      includeReturn: false,
+    })
+
+    expect(result.success).toBe(false)
+    expect(store.updateCalls).toHaveLength(0)
+    expect(store.rows.get(OUTBOUND)?.status).toBe("rejected")
+    expect(mockSendNotification).not.toHaveBeenCalled()
+  })
+
+  it("audits + re-requests a rejected leg for the SAME driver (SEC-M15-199-003)", async () => {
+    store.rows.set(OUTBOUND, {
+      id: OUTBOUND,
+      status: "rejected",
+      driver_id: DRIVER,
+      date: "2026-08-01",
+      pickup_time: "09:00:00",
+      parent_ride_id: null,
+    })
+
+    const result = await assignDriverWithReturn(OUTBOUND, DRIVER, {
+      includeReturn: false,
+    })
+
+    expect(result.success).toBe(true)
+    expect(store.rows.get(OUTBOUND)?.status).toBe("planned")
+    // Fresh request fired despite driverChanged === false…
+    expect(mockSendNotification).toHaveBeenCalledWith(OUTBOUND, DRIVER)
+    expect(mockCreateTracking).toHaveBeenCalledTimes(1)
+    // …and the status-only change lands in the audit_log, marked as re-request.
+    expect(mockLogAudit).toHaveBeenCalledTimes(1)
+    expect(mockLogAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "assign",
+        entityId: OUTBOUND,
+        metadata: expect.objectContaining({ re_request: true }),
+      })
+    )
+  })
+
   it("rejects unauthenticated callers", async () => {
     mockRequireAuth.mockResolvedValue({
       authorized: false,

--- a/src/actions/rides.ts
+++ b/src/actions/rides.ts
@@ -1215,6 +1215,13 @@ export async function assignDriver(
     updateData.status = "planned"
   }
 
+  // Auto-transition: rejected -> planned on re-assignment (state machine allows
+  // it; #169). Triggers the regular request side effects below, so the new
+  // driver gets a fresh acceptance request instead of a silently rejected ride.
+  if (currentRide.status === "rejected" && driverId) {
+    updateData.status = "planned"
+  }
+
   // Auto-transition: planned -> unplanned when driver is removed
   if (
     currentRide.status === "planned" &&

--- a/src/actions/rides.ts
+++ b/src/actions/rides.ts
@@ -1182,11 +1182,18 @@ export async function assignDriver(
     return { success: false, error: "Fahrt nicht gefunden" }
   }
 
-  // Availability / absence guard (Issue #104): only when a *new* driver is
-  // being assigned. Block absent drivers; remember out-of-availability so we
-  // can note it in the communication_log after a successful update.
+  // Availability / absence guard (Issue #104): whenever the call results in a
+  // (new or renewed) request — a new driver, or a re-request to the SAME
+  // driver on a rejected ride (SEC-M15-199-001: the guard must hang on the
+  // operation, not the driver change, or the rejected→planned path would
+  // bypass the absence check). Block absent drivers; remember
+  // out-of-availability so we can note it in the communication_log after a
+  // successful update.
   let driverStatus: DriverDayStatus | null = null
-  if (driverId && driverId !== currentRide.driver_id) {
+  if (
+    driverId &&
+    (driverId !== currentRide.driver_id || currentRide.status === "rejected")
+  ) {
     driverStatus = await getDriverDayStatus(
       supabase,
       driverId,
@@ -1244,9 +1251,11 @@ export async function assignDriver(
   const newStatus = updateData.status ?? currentRide.status
 
   // Manipulation-safe audit trail for every assignment/removal (finding #181):
-  // assignDriver previously wrote no audit_log entry. "assign" when a driver is
-  // set, "reassign" when a driver is removed or replaced.
-  if (driverChanged) {
+  // "assign" when a driver is set, "reassign" when a driver is removed or
+  // replaced. Also logged when only the STATUS changes (re-request to the same
+  // driver after a rejection, rejected→planned) — SEC-M15-199-003: that path
+  // sends a fresh request mail and must not escape the audit_log.
+  if (driverChanged || updateData.status !== undefined) {
     logAudit({
       userId: auth.userId,
       userRole: auth.role,
@@ -1257,6 +1266,7 @@ export async function assignDriver(
         driver_id: { old: currentRide.driver_id, new: driverId },
         status: { old: currentRide.status, new: newStatus },
       },
+      ...(driverChanged ? {} : { metadata: { re_request: true } }),
     }).catch(() => {})
   }
 
@@ -1446,9 +1456,10 @@ export async function assignDriverWithReturn(
 
   for (const { row, role } of legRows) {
     let driverStatus: DriverDayStatus | null = null
-    // Only guard when a *different* driver is being assigned (matches the
-    // single-assign flow — reassigning the same driver skips the check).
-    if (driverId !== row.driver_id) {
+    // Guard when a *different* driver is assigned OR the leg is re-requested
+    // after a rejection (rejected→planned also fires for the same driver;
+    // SEC-M15-199-001 — matches the single-assign flow).
+    if (driverId !== row.driver_id || row.status === "rejected") {
       driverStatus = await getDriverDayStatus(
         supabase,
         driverId,
@@ -1521,8 +1532,10 @@ export async function assignDriverWithReturn(
     const row = source.row
     assignedRideIds.push(leg.rideId)
 
-    // Manipulation-safe audit trail for every assignment (#181).
-    if (leg.driverChanged) {
+    // Manipulation-safe audit trail for every assignment (#181). Status-only
+    // changes (rejected→planned re-request to the same driver) are logged too
+    // (SEC-M15-199-003).
+    if (leg.driverChanged || leg.statusChanged) {
       logAudit({
         userId: auth.userId,
         userRole: auth.role,
@@ -1533,7 +1546,11 @@ export async function assignDriverWithReturn(
           driver_id: { old: row.driver_id, new: driverId },
           status: { old: row.status, new: leg.targetStatus },
         },
-        metadata: { co_assign: true, leg: leg.role },
+        metadata: {
+          co_assign: true,
+          leg: leg.role,
+          ...(leg.driverChanged ? {} : { re_request: true }),
+        },
       }).catch(() => {})
     }
 

--- a/src/app/(dashboard)/dispatch/page.tsx
+++ b/src/app/(dashboard)/dispatch/page.tsx
@@ -95,7 +95,7 @@ async function renderSplitView(weekStart: string, today: string) {
     supabase
       .from("rides")
       .select(
-        "id, date, pickup_time, status, direction, driver_id, parent_ride_id, requirements, patients(first_name, last_name, city), destinations(display_name)"
+        "id, date, pickup_time, status, direction, driver_id, parent_ride_id, duration_seconds, requirements, patients(first_name, last_name, city), destinations(display_name)"
       )
       .gte("date", weekStart)
       .lte("date", weekEnd)
@@ -236,6 +236,8 @@ async function renderSplitView(weekStart: string, today: string) {
       destination_name: destination?.display_name ?? "–",
       requirements: r.requirements ?? [],
       parent_ride_id: r.parent_ride_id,
+      driver_id: r.driver_id,
+      duration_seconds: r.duration_seconds,
       assigned_driver_name: r.driver_id
         ? driverNameById.get(r.driver_id) ?? null
         : null,
@@ -278,6 +280,13 @@ async function renderSplitView(weekStart: string, today: string) {
       // Neutral: end date only, never the reason (#187).
       absent_until: coveringAbsence?.end_date ?? null,
       period_ride_count: periodRideCount.get(d.id) ?? 0,
+      availability,
+      // Strip the absence type before it crosses to the client (#187): the
+      // context filter (#169) only needs the neutral date range.
+      absences: absences.map((a) => ({
+        start_date: a.start_date,
+        end_date: a.end_date,
+      })),
     }
   })
 

--- a/src/components/dispatch/driver-card.tsx
+++ b/src/components/dispatch/driver-card.tsx
@@ -2,44 +2,79 @@
 
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { VEHICLE_TYPE_LABELS } from "@/lib/rides/constants"
 import { formatDayLabel } from "@/lib/utils/dates"
+import type { DriverRideContext } from "@/lib/dispatch/driver-context"
 import type { SplitDriver } from "@/components/dispatch/split-view-types"
 
 interface DriverCardProps {
   driver: SplitDriver
+  /**
+   * Context relative to the ACTIVE ride (#169), or null when no ride is
+   * selected (default panel: today's availability, display-only).
+   */
+  context?: DriverRideContext | null
+  /** Assign affordance — only rendered when `context` is present + assignable. */
+  onAssign?: (driver: SplitDriver) => void
+  /** Disables the assign button while a request is in flight. */
+  assignPending?: boolean
 }
 
 /**
- * A single driver card in the split-view right column (M15, #168).
+ * A single driver card in the split-view right column (M15, #168/#169).
  *
- * Shows name, vehicle type, today's availability short-info and the ride count
- * for the selected period. Display-only in the grundgerüst — the `[Zuweisen]`
- * button, context grouping (Verfügbar/Konflikt/Nicht verfügbar) and drop-target
- * behaviour arrive with #169/#170.
+ * Without an active ride: name, vehicle type, today's availability short-info
+ * and the ride count for the selected period. With an active ride the card
+ * shows the driver's context to THAT ride — verfügbar (green, [Zuweisen]),
+ * Konflikt/Ausserhalb (grayed with Grund, still assignable behind the
+ * «Trotzdem zuweisen» pre-question) or abwesend (grayed, not assignable).
  *
  * #187: an absence renders as a NEUTRAL "Nicht verfügbar bis …" — the absence
  * REASON (e.g. Krankheit) is never surfaced here.
  */
-export function DriverCard({ driver }: DriverCardProps) {
+export function DriverCard({
+  driver,
+  context = null,
+  onAssign,
+  assignPending = false,
+}: DriverCardProps) {
   const availableToday = !driver.is_absent_today && driver.today_slots.length > 0
+
+  // Card tint: with context it encodes the context state, otherwise today's
+  // availability (grundgerüst behavior).
+  const highlighted = context ? context.state === "verfuegbar" : availableToday
 
   return (
     <div
       className={cn(
-        "flex items-center justify-between rounded-md border px-3 py-2",
-        availableToday
+        "flex items-center justify-between gap-2 rounded-md border px-3 py-2",
+        highlighted
           ? "border-green-200 bg-green-50"
-          : "border-gray-200 bg-gray-50"
+          : "border-gray-200 bg-gray-50",
+        context && !context.assignable && "opacity-60"
       )}
     >
-      <div className="flex flex-col">
-        <span className="text-sm font-medium">
+      <div className="flex min-w-0 flex-col">
+        <span className="truncate text-sm font-medium">
           {driver.last_name}, {driver.first_name}
         </span>
         <span className="text-xs text-muted-foreground">
           {VEHICLE_TYPE_LABELS[driver.vehicle_type]}
-          {driver.is_absent_today ? (
+          {context ? (
+            context.reason && (
+              <>
+                {" · "}
+                <span
+                  className={cn(
+                    context.state === "konflikt" && "text-amber-700"
+                  )}
+                >
+                  {context.reason}
+                </span>
+              </>
+            )
+          ) : driver.is_absent_today ? (
             <>
               {" · "}
               <span>
@@ -57,7 +92,7 @@ export function DriverCard({ driver }: DriverCardProps) {
         </span>
       </div>
 
-      <div className="flex items-center gap-2">
+      <div className="flex shrink-0 items-center gap-2">
         <Badge
           variant={driver.period_ride_count > 0 ? "default" : "secondary"}
           className="tabular-nums"
@@ -65,14 +100,36 @@ export function DriverCard({ driver }: DriverCardProps) {
         >
           {driver.period_ride_count}
         </Badge>
-        <span
-          className={cn(
-            "h-2.5 w-2.5 shrink-0 rounded-full",
-            availableToday ? "bg-green-500" : "bg-gray-300"
-          )}
-          title={availableToday ? "Heute verfügbar" : "Heute nicht verfügbar"}
-          aria-label={availableToday ? "Heute verfügbar" : "Heute nicht verfügbar"}
-        />
+        {context ? (
+          context.assignable && onAssign ? (
+            <Button
+              size="sm"
+              variant={context.state === "verfuegbar" ? "default" : "outline"}
+              disabled={assignPending}
+              onClick={() => onAssign(driver)}
+              aria-label={`${driver.first_name} ${driver.last_name} zuweisen`}
+            >
+              Zuweisen
+            </Button>
+          ) : (
+            <span
+              className="h-2.5 w-2.5 shrink-0 rounded-full bg-gray-300"
+              title="Nicht zuweisbar"
+              aria-label="Nicht zuweisbar"
+            />
+          )
+        ) : (
+          <span
+            className={cn(
+              "h-2.5 w-2.5 shrink-0 rounded-full",
+              availableToday ? "bg-green-500" : "bg-gray-300"
+            )}
+            title={availableToday ? "Heute verfügbar" : "Heute nicht verfügbar"}
+            aria-label={
+              availableToday ? "Heute verfügbar" : "Heute nicht verfügbar"
+            }
+          />
+        )}
       </div>
     </div>
   )

--- a/src/components/dispatch/driver-column.tsx
+++ b/src/components/dispatch/driver-column.tsx
@@ -1,7 +1,28 @@
 "use client"
 
+import { useCallback, useMemo, useState, useTransition } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Label } from "@/components/ui/label"
+import { useToast } from "@/hooks/use-toast"
 import { DriverCard } from "@/components/dispatch/driver-card"
+import { tripLabel } from "@/components/dispatch/ride-card"
+import { assignDriver, assignDriverWithReturn } from "@/actions/rides"
+import {
+  resolveDriverRideContext,
+  sortDriversByContext,
+  type DriverRideContext,
+} from "@/lib/dispatch/driver-context"
 import { formatDayLabel } from "@/lib/utils/dates"
 import type {
   SplitDriver,
@@ -10,44 +31,272 @@ import type {
 
 interface DriverColumnProps {
   drivers: SplitDriver[]
-  /**
-   * The currently activated ride, if any. In the grundgerüst this only drives a
-   * context header; the actual availability grouping/sorting + `[Zuweisen]`
-   * (Verfügbar/Konflikt/Nicht verfügbar) is Issue #169. Kept as a prop so #169
-   * can dock without touching the layout.
-   */
+  /** All rides of the period — needed for time-conflict detection (#169). */
+  rides: SplitRide[]
+  /** The currently activated ride; drives context filtering + assignment. */
   activeRide: SplitRide | null
+  /** Called after a successful assignment (parent clears the selection). */
+  onAssigned?: () => void
+}
+
+/** "HH:MM:SS" | "HH:MM" -> "HH:MM". */
+function formatTime(time: string): string {
+  return time.slice(0, 5)
 }
 
 /**
- * Right column of the split-view: the driver panel (M15, #168).
+ * Right column of the split-view: the driver panel (M15, #168/#169).
  *
- * Without an active ride it shows a flat, alphabetical list of active drivers
- * with today's availability. It is `sticky` on desktop so the driver context
- * stays visible while the (potentially long) ride list scrolls (Kim §1).
+ * Without an active ride: flat alphabetical list with today's availability.
+ * With an active ride the panel re-sorts by context — drivers available at the
+ * ride's pickup time and without an overlapping ride on top, everyone else
+ * grayed WITH the reason (concept §2.2). Assignment runs through [Zuweisen] →
+ * (optional «Trotzdem zuweisen?» pre-question for Konflikt/Ausserhalb, #104
+ * pattern) → confirm dialog with the Rückfahrt checkbox (#167) → server action.
+ *
+ * Absent drivers are never assignable here; the server guard (#182) would
+ * reject them anyway — the UI gray-out is convenience, not the control.
  */
-export function DriverColumn({ drivers, activeRide }: DriverColumnProps) {
+export function DriverColumn({
+  drivers,
+  rides,
+  activeRide,
+  onAssigned,
+}: DriverColumnProps) {
+  const { toast } = useToast()
+  const [isPending, startTransition] = useTransition()
+
+  /** Pre-question state («Trotzdem zuweisen?») for Konflikt/Ausserhalb. */
+  const [override, setOverride] = useState<{
+    driver: SplitDriver
+    context: DriverRideContext
+  } | null>(null)
+  /** Confirm dialog state («Fahrt anfragen?»). */
+  const [confirmDriver, setConfirmDriver] = useState<SplitDriver | null>(null)
+  const [includeReturn, setIncludeReturn] = useState(true)
+
+  // Assignment is offered for rides still looking for a driver. Angefragt /
+  // Bestätigt cards give context only — Umplanung is a separate flow.
+  const assignMode =
+    activeRide !== null &&
+    (activeRide.assignmentStatus === "offen" ||
+      activeRide.assignmentStatus === "abgelehnt")
+
+  // -- Context resolution + sorting (pure logic in driver-context.ts) --
+  const contextById = useMemo(() => {
+    const map = new Map<string, DriverRideContext>()
+    if (!activeRide) return map
+    for (const driver of drivers) {
+      map.set(driver.id, resolveDriverRideContext(activeRide, driver, rides))
+    }
+    return map
+  }, [activeRide, drivers, rides])
+
+  const orderedDrivers = useMemo(
+    () =>
+      activeRide ? sortDriversByContext(drivers, contextById) : drivers,
+    [activeRide, drivers, contextById]
+  )
+
+  const availableCount = useMemo(() => {
+    let n = 0
+    for (const ctx of contextById.values()) {
+      if (ctx.state === "verfuegbar") n++
+    }
+    return n
+  }, [contextById])
+
+  // -- Assign flow --
+
+  const openConfirm = useCallback(
+    (driver: SplitDriver) => {
+      // Rückfahrt mitanfragen is on by default when a linked leg exists (#169).
+      setIncludeReturn(activeRide?.linked_return_time !== null)
+      setConfirmDriver(driver)
+    },
+    [activeRide]
+  )
+
+  const handleAssignClick = useCallback(
+    (driver: SplitDriver) => {
+      const context = contextById.get(driver.id)
+      if (!context || !context.assignable) return
+      if (context.needsOverride) {
+        setOverride({ driver, context })
+        return
+      }
+      openConfirm(driver)
+    },
+    [contextById, openConfirm]
+  )
+
+  const handleOverrideConfirm = useCallback(() => {
+    if (override) openConfirm(override.driver)
+    setOverride(null)
+  }, [override, openConfirm])
+
+  const handleSendRequest = useCallback(() => {
+    if (!activeRide || !confirmDriver) return
+    const ride = activeRide
+    const driver = confirmDriver
+    const withReturn = ride.linked_return_time !== null
+    const driverName = `${driver.first_name} ${driver.last_name}`
+    setConfirmDriver(null)
+
+    startTransition(async () => {
+      let returnSkipped = false
+
+      if (withReturn) {
+        const result = await assignDriverWithReturn(ride.id, driver.id, {
+          includeReturn,
+        })
+        if (!result.success) {
+          toast({
+            variant: "destructive",
+            title: "Anfrage fehlgeschlagen",
+            description:
+              result.error ?? "Unbekannter Fehler bei der Zuweisung.",
+          })
+          return
+        }
+        returnSkipped =
+          includeReturn &&
+          result.data.returnLegSkippedReason === "not_assignable"
+      } else {
+        const result = await assignDriver(ride.id, driver.id)
+        if (!result.success) {
+          toast({
+            variant: "destructive",
+            title: "Anfrage fehlgeschlagen",
+            description:
+              result.error ?? "Unbekannter Fehler bei der Zuweisung.",
+          })
+          return
+        }
+      }
+
+      toast({
+        title: `Anfrage an ${driverName} gesendet`,
+        description: returnSkipped
+          ? "Die Fahrt ist jetzt angefragt. Die Rückfahrt konnte nicht mit angefragt werden (nicht mehr zuweisbar)."
+          : withReturn && includeReturn
+            ? "Fahrt und Rückfahrt sind jetzt angefragt."
+            : "Die Fahrt ist jetzt angefragt.",
+      })
+      onAssigned?.()
+    })
+  }, [activeRide, confirmDriver, includeReturn, toast, onAssigned])
+
+  // -- Dialog copy --
+
+  const overrideTitle =
+    override?.context.state === "konflikt"
+      ? "Zeitkonflikt"
+      : "Ausserhalb der Verfügbarkeit"
+
   return (
-    <Card className="lg:sticky lg:top-4">
-      <CardHeader className="pb-3">
-        <CardTitle className="text-base">Fahrer</CardTitle>
-        {activeRide && (
-          <p className="text-xs text-muted-foreground">
-            Aktive Fahrt: {formatDayLabel(activeRide.date)}{" "}
-            {activeRide.pickup_time.slice(0, 5)} {"·"}{" "}
-            {activeRide.destination_name}
-          </p>
-        )}
-      </CardHeader>
-      <CardContent className="space-y-2">
-        {drivers.length === 0 ? (
-          <p className="text-sm text-muted-foreground">Keine aktiven Fahrer</p>
-        ) : (
-          drivers.map((driver) => (
-            <DriverCard key={driver.id} driver={driver} />
-          ))
-        )}
-      </CardContent>
-    </Card>
+    <>
+      <Card className="lg:sticky lg:top-4">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Fahrer</CardTitle>
+          {activeRide && (
+            <p className="text-xs text-muted-foreground">
+              Aktive Fahrt: {formatDayLabel(activeRide.date)}{" "}
+              {formatTime(activeRide.pickup_time)} {"·"}{" "}
+              {activeRide.destination_name}
+              {" — "}
+              <span className="tabular-nums">{availableCount}</span> verfügbar
+            </p>
+          )}
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {drivers.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Keine aktiven Fahrer</p>
+          ) : (
+            orderedDrivers.map((driver) => (
+              <DriverCard
+                key={driver.id}
+                driver={driver}
+                context={activeRide ? contextById.get(driver.id) ?? null : null}
+                onAssign={assignMode ? handleAssignClick : undefined}
+                assignPending={isPending}
+              />
+            ))
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Pre-question: assignment despite conflict / outside availability. */}
+      <AlertDialog
+        open={override !== null}
+        onOpenChange={(open) => !open && setOverride(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{overrideTitle}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {override && (
+                <>
+                  {override.driver.first_name} {override.driver.last_name}
+                  {": "}
+                  {override.context.reason}. Trotzdem zuweisen?
+                </>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Abbrechen</AlertDialogCancel>
+            <AlertDialogAction onClick={handleOverrideConfirm}>
+              Trotzdem zuweisen
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Confirm dialog: «Fahrt anfragen?» (wording per #169). */}
+      <AlertDialog
+        open={confirmDriver !== null}
+        onOpenChange={(open) => !open && setConfirmDriver(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Fahrt anfragen?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {activeRide && confirmDriver && (
+                <>
+                  {formatDayLabel(activeRide.date)},{" "}
+                  {formatTime(activeRide.pickup_time)} Uhr —{" "}
+                  {tripLabel(activeRide)} an {confirmDriver.first_name}{" "}
+                  {confirmDriver.last_name} anfragen?
+                </>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          {activeRide?.linked_return_time && (
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="include-return"
+                checked={includeReturn}
+                onCheckedChange={(checked) =>
+                  setIncludeReturn(checked === true)
+                }
+              />
+              <Label htmlFor="include-return" className="text-sm font-normal">
+                Rückfahrt {formatTime(activeRide.linked_return_time)} Uhr mit
+                anfragen
+              </Label>
+            </div>
+          )}
+
+          <AlertDialogFooter>
+            <AlertDialogCancel>Abbrechen</AlertDialogCancel>
+            <AlertDialogAction onClick={handleSendRequest}>
+              Anfrage senden
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   )
 }

--- a/src/components/dispatch/ride-card.tsx
+++ b/src/components/dispatch/ride-card.tsx
@@ -31,8 +31,9 @@ function formatEventTime(iso: string): string {
  * Build the "Von → Nach" label from trip direction. The patient's home town is
  * one end, the facility the other. Falls back gracefully when the city is
  * missing (only operationally relevant location data is shown — #179).
+ * Exported for the assign confirm dialog (#169), which names the same trip.
  */
-function tripLabel(ride: SplitRide): string {
+export function tripLabel(ride: SplitRide): string {
   const home = ride.patient_city?.trim() || "Zuhause"
   const facility = ride.destination_name
   switch (ride.direction) {

--- a/src/components/dispatch/split-view-types.ts
+++ b/src/components/dispatch/split-view-types.ts
@@ -9,6 +9,7 @@
 
 import type { Enums } from "@/lib/types/database"
 import type { AssignmentStatus } from "@/lib/dispatch/assignment-status"
+import type { AvailabilityRow } from "@/lib/availability/driver-status"
 
 type RideStatus = Enums<"ride_status">
 type RideDirection = Enums<"ride_direction">
@@ -33,6 +34,10 @@ export interface SplitRide {
   /** Operationally relevant transport requirements (wheelchair, companion, …). */
   requirements: RideRequirement[]
   parent_ride_id: string | null
+  /** Assigned/requested driver id — needed for conflict detection (#169). */
+  driver_id: string | null
+  /** Route duration; null until calculated. Conflict window fallback: 60 min. */
+  duration_seconds: number | null
   /** Currently requested driver, shown on Angefragt cards ("→ angefragt: …"). */
   assigned_driver_name: string | null
   /** Pickup time of the linked return ride, if any ("↩ Rückfahrt 11:00"). */
@@ -71,4 +76,20 @@ export interface SplitDriver {
   absent_until: string | null
   /** Number of rides assigned to this driver in the selected period (week). */
   period_ride_count: number
+  /**
+   * Raw `driver_availability` rows (weekly grid + upcoming date exceptions),
+   * so the client can resolve windows for the ACTIVE ride's date (#169).
+   */
+  availability: AvailabilityRow[]
+  /**
+   * Approved absence date ranges. Deliberately WITHOUT the absence type/reason
+   * (#187) — the wire format itself is neutral, not just the rendering.
+   */
+  absences: SplitDriverAbsence[]
+}
+
+/** Neutral absence range (no type/reason — #187 data minimization). */
+export interface SplitDriverAbsence {
+  start_date: string
+  end_date: string
 }

--- a/src/components/dispatch/split-view.tsx
+++ b/src/components/dispatch/split-view.tsx
@@ -20,13 +20,13 @@ interface SplitViewProps {
  *
  * Owns the two pieces of client state the grundgerüst needs:
  *   - `activeTab`     — which of the four assignment buckets is shown.
- *   - `selectedRideId`— the "activated" ride. This is the docking point for the
- *     context-filtering + assign flow (#169): the driver panel already receives
- *     the active ride, it just doesn't filter/sort by it yet.
+ *   - `selectedRideId`— the "activated" ride. It drives the context-filtering +
+ *     assign flow in the driver panel (#169); a successful assignment clears
+ *     the selection so the panel returns to its neutral state.
  *
  * A separate `detailRideId` drives the existing `RideQuickSheet` (ride detail).
- * Assign button, drag & drop and the live countdown are deliberately absent
- * here — they land in #169/#170/#171.
+ * Drag & drop and the live countdown are deliberately absent here — they land
+ * in #170/#171.
  */
 export function SplitView({ rides, drivers }: SplitViewProps) {
   // Default to the first tab (in order) that actually has rides, else "offen".
@@ -66,7 +66,12 @@ export function SplitView({ rides, drivers }: SplitViewProps) {
           onSelectRide={handleSelectRide}
           onOpenDetail={handleOpenDetail}
         />
-        <DriverColumn drivers={drivers} activeRide={activeRide} />
+        <DriverColumn
+          drivers={drivers}
+          rides={rides}
+          activeRide={activeRide}
+          onAssigned={() => setSelectedRideId(null)}
+        />
       </div>
 
       <RideQuickSheet

--- a/src/lib/dispatch/__tests__/driver-context.test.ts
+++ b/src/lib/dispatch/__tests__/driver-context.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from "vitest"
+import {
+  resolveDriverRideContext,
+  sortDriversByContext,
+  type DriverRideContext,
+} from "@/lib/dispatch/driver-context"
+import type {
+  SplitDriver,
+  SplitRide,
+} from "@/components/dispatch/split-view-types"
+
+// -- Fixtures ----------------------------------------------------------------
+
+/** Thursday 2026-07-16 is a real Thursday. */
+const RIDE_DATE = "2026-07-16"
+
+function makeRide(overrides: Partial<SplitRide> = {}): SplitRide {
+  return {
+    id: "ride-active",
+    date: RIDE_DATE,
+    pickup_time: "08:30:00",
+    status: "unplanned",
+    assignmentStatus: "offen",
+    direction: "outbound",
+    patient_first_name: "Hans",
+    patient_last_name: "Brunner",
+    patient_city: "Muri AG",
+    destination_name: "KSA Aarau",
+    requirements: [],
+    parent_ride_id: null,
+    driver_id: null,
+    duration_seconds: 1800, // 30 min
+    assigned_driver_name: null,
+    linked_return_time: null,
+    overdue: false,
+    rejected_by_name: null,
+    rejected_at: null,
+    ...overrides,
+  }
+}
+
+function makeDriver(overrides: Partial<SplitDriver> = {}): SplitDriver {
+  return {
+    id: "driver-1",
+    first_name: "Ruth",
+    last_name: "Meier",
+    vehicle_type: "standard",
+    today_slots: [],
+    is_absent_today: false,
+    absent_until: null,
+    period_ride_count: 0,
+    // Thursday 08:00–12:00 by default
+    availability: [
+      {
+        day_of_week: "thursday",
+        specific_date: null,
+        start_time: "08:00:00",
+        end_time: "12:00:00",
+      },
+    ],
+    absences: [],
+    ...overrides,
+  }
+}
+
+// -- resolveDriverRideContext ------------------------------------------------
+
+describe("resolveDriverRideContext", () => {
+  it("is verfuegbar when the pickup time is inside a window and no conflict exists", () => {
+    const ctx = resolveDriverRideContext(makeRide(), makeDriver(), [makeRide()])
+    expect(ctx.state).toBe("verfuegbar")
+    expect(ctx.reason).toBeNull()
+    expect(ctx.assignable).toBe(true)
+    expect(ctx.needsOverride).toBe(false)
+  })
+
+  it("is abwesend (not assignable) when an absence covers the ride date", () => {
+    const driver = makeDriver({
+      absences: [{ start_date: "2026-07-10", end_date: "2026-07-20" }],
+    })
+    const ctx = resolveDriverRideContext(makeRide(), driver, [makeRide()])
+    expect(ctx.state).toBe("abwesend")
+    expect(ctx.assignable).toBe(false)
+    expect(ctx.needsOverride).toBe(false)
+    expect(ctx.reason).toContain("Nicht verfügbar bis")
+    expect(ctx.reason).toContain("20.07.")
+  })
+
+  it("never leaks an absence reason — only the neutral date range exists", () => {
+    // #187 holds by construction: SplitDriverAbsence has no type/reason field.
+    const driver = makeDriver({
+      absences: [{ start_date: RIDE_DATE, end_date: RIDE_DATE }],
+    })
+    const ctx = resolveDriverRideContext(makeRide(), driver, [makeRide()])
+    expect(ctx.reason).not.toMatch(/krank|ferien|urlaub/i)
+  })
+
+  it("flags a time conflict with an overlapping requested ride (with window)", () => {
+    const active = makeRide()
+    const other = makeRide({
+      id: "ride-other",
+      pickup_time: "08:00:00",
+      duration_seconds: 3600, // 08:00–09:00 overlaps 08:30–09:00
+      status: "planned",
+      assignmentStatus: "angefragt",
+      driver_id: "driver-1",
+    })
+    const ctx = resolveDriverRideContext(active, makeDriver(), [active, other])
+    expect(ctx.state).toBe("konflikt")
+    expect(ctx.reason).toBe("Fährt bereits 08:00–09:00")
+    expect(ctx.assignable).toBe(true)
+    expect(ctx.needsOverride).toBe(true)
+  })
+
+  it("uses the 60-min fallback when the other ride has no duration", () => {
+    const active = makeRide({ pickup_time: "08:50:00" })
+    const other = makeRide({
+      id: "ride-other",
+      pickup_time: "08:00:00",
+      duration_seconds: null, // 08:00–09:00 fallback
+      status: "confirmed",
+      assignmentStatus: "bestaetigt",
+      driver_id: "driver-1",
+    })
+    const ctx = resolveDriverRideContext(active, makeDriver(), [active, other])
+    expect(ctx.state).toBe("konflikt")
+  })
+
+  it("ignores rides on other dates, other drivers and non-active buckets", () => {
+    const active = makeRide()
+    const sameTimeOtherDay = makeRide({
+      id: "r1",
+      date: "2026-07-17",
+      driver_id: "driver-1",
+      status: "confirmed",
+      assignmentStatus: "bestaetigt",
+    })
+    const otherDriver = makeRide({
+      id: "r2",
+      driver_id: "driver-2",
+      status: "confirmed",
+      assignmentStatus: "bestaetigt",
+    })
+    const openRide = makeRide({ id: "r3", driver_id: "driver-1" }) // offen
+    const ctx = resolveDriverRideContext(active, makeDriver(), [
+      active,
+      sameTimeOtherDay,
+      otherDriver,
+      openRide,
+    ])
+    expect(ctx.state).toBe("verfuegbar")
+  })
+
+  it("does not count the linked return leg as a conflict", () => {
+    // Outbound 08:30 with linked return leg 08:45 (same trip, overlapping
+    // fallback windows) — co-assigning both to one driver is the GOAL.
+    const active = makeRide()
+    const returnLeg = makeRide({
+      id: "ride-return",
+      pickup_time: "08:45:00",
+      parent_ride_id: "ride-active",
+      status: "planned",
+      assignmentStatus: "angefragt",
+      driver_id: "driver-1",
+    })
+    const ctx = resolveDriverRideContext(active, makeDriver(), [
+      active,
+      returnLeg,
+    ])
+    expect(ctx.state).toBe("verfuegbar")
+  })
+
+  it("is ausserhalb with the driver's actual windows when the time misses them", () => {
+    const active = makeRide({ pickup_time: "14:00:00" })
+    const ctx = resolveDriverRideContext(active, makeDriver(), [active])
+    expect(ctx.state).toBe("ausserhalb")
+    expect(ctx.reason).toBe("Verfügbar 08:00–12:00")
+    expect(ctx.assignable).toBe(true)
+    expect(ctx.needsOverride).toBe(true)
+  })
+
+  it("is ausserhalb with a schema hint when the driver has no windows that day", () => {
+    const driver = makeDriver({ availability: [] })
+    const ctx = resolveDriverRideContext(makeRide(), driver, [makeRide()])
+    expect(ctx.state).toBe("ausserhalb")
+    expect(ctx.reason).toBe("Laut Wochenschema nicht verfügbar")
+  })
+
+  it("prefers absence over conflict and conflict over availability", () => {
+    const active = makeRide()
+    const overlapping = makeRide({
+      id: "ride-other",
+      status: "confirmed",
+      assignmentStatus: "bestaetigt",
+      driver_id: "driver-1",
+    })
+    // Absent + conflicting + outside → abwesend wins.
+    const absent = makeDriver({
+      availability: [],
+      absences: [{ start_date: RIDE_DATE, end_date: RIDE_DATE }],
+    })
+    expect(
+      resolveDriverRideContext(active, absent, [active, overlapping]).state
+    ).toBe("abwesend")
+    // Conflicting + outside → konflikt wins.
+    const conflicting = makeDriver({ availability: [] })
+    expect(
+      resolveDriverRideContext(active, conflicting, [active, overlapping]).state
+    ).toBe("konflikt")
+  })
+})
+
+// -- sortDriversByContext ----------------------------------------------------
+
+describe("sortDriversByContext", () => {
+  const ctx = (state: DriverRideContext["state"]): DriverRideContext => ({
+    state,
+    reason: state === "verfuegbar" ? null : "x",
+    assignable: state !== "abwesend",
+    needsOverride: state === "konflikt" || state === "ausserhalb",
+  })
+
+  it("orders verfuegbar → konflikt → ausserhalb → abwesend, alphabetical within", () => {
+    const drivers = [
+      makeDriver({ id: "a", last_name: "Steiner" }), // abwesend
+      makeDriver({ id: "b", last_name: "Frei" }), // verfuegbar
+      makeDriver({ id: "c", last_name: "Zbinden" }), // verfuegbar
+      makeDriver({ id: "d", last_name: "Meier" }), // konflikt
+      makeDriver({ id: "e", last_name: "Arnold" }), // ausserhalb
+    ]
+    const map = new Map<string, DriverRideContext>([
+      ["a", ctx("abwesend")],
+      ["b", ctx("verfuegbar")],
+      ["c", ctx("verfuegbar")],
+      ["d", ctx("konflikt")],
+      ["e", ctx("ausserhalb")],
+    ])
+    expect(sortDriversByContext(drivers, map).map((d) => d.id)).toEqual([
+      "b",
+      "c",
+      "d",
+      "e",
+      "a",
+    ])
+  })
+})

--- a/src/lib/dispatch/driver-context.ts
+++ b/src/lib/dispatch/driver-context.ts
@@ -1,0 +1,210 @@
+/**
+ * Driver context resolution for the /dispatch split-view (M15, Issue #169).
+ *
+ * When the dispatcher activates a ride in the left column, the driver panel
+ * filters and sorts by that ride: drivers who are available at the ride's
+ * pickup time AND have no overlapping ride float to the top; everyone else is
+ * grayed out WITH a reason («Ferien bis 20.7.», «Fährt bereits 08:00–10:00»).
+ *
+ * Pure module (no DB/React/Next) in the style of `assignment-status.ts` /
+ * `co-assign.ts` so the ranking + reason logic is unit-testable. The absence
+ * REASON is never part of the inputs — the server ships only neutral date
+ * ranges (#187), so the strictest guarantee holds by construction.
+ */
+
+import {
+  resolveAvailability,
+  toAvailabilityEntries,
+  type TimeWindow,
+} from "@/lib/availability/resolve"
+import { isTimeWithinWindows } from "@/lib/availability/driver-status"
+import { formatDayLabel } from "@/lib/utils/dates"
+import type {
+  SplitDriver,
+  SplitRide,
+} from "@/components/dispatch/split-view-types"
+
+/**
+ * Context state of one driver relative to the active ride, in display order:
+ *
+ *  - `verfuegbar`  — inside an availability window, no overlapping ride.
+ *  - `konflikt`    — has a time-overlapping ride that day (assignable behind
+ *                    the «Trotzdem zuweisen» pre-question).
+ *  - `ausserhalb`  — no availability window covering the pickup time
+ *                    (assignable behind the same pre-question, #104 pattern).
+ *  - `abwesend`    — approved absence covering the ride date. NOT assignable;
+ *                    `assignDriver` would hard-reject it server-side anyway.
+ */
+export type DriverContextState =
+  | "verfuegbar"
+  | "konflikt"
+  | "ausserhalb"
+  | "abwesend"
+
+/** Sort rank per state (lower = higher up in the panel). */
+const STATE_RANK: Record<DriverContextState, number> = {
+  verfuegbar: 0,
+  konflikt: 1,
+  ausserhalb: 2,
+  abwesend: 3,
+}
+
+export interface DriverRideContext {
+  state: DriverContextState
+  /** Human-readable Grund for grayed states; null when `verfuegbar`. */
+  reason: string | null
+  /** Whether a [Zuweisen] action is offered at all (false only for absent). */
+  assignable: boolean
+  /**
+   * Whether assigning needs the separate «Trotzdem zuweisen?» pre-question
+   * before the regular confirm dialog (konflikt / ausserhalb).
+   */
+  needsOverride: boolean
+}
+
+/** Default ride duration when the route has not been calculated (60 min). */
+const DEFAULT_RIDE_DURATION_SECONDS = 3600
+
+/** "HH:MM[:SS]" -> minutes since midnight. */
+function timeToMinutes(time: string): number {
+  const [h = "0", m = "0"] = time.split(":")
+  return parseInt(h, 10) * 60 + parseInt(m, 10)
+}
+
+/** Minutes since midnight -> "HH:MM". */
+function minutesToTime(totalMinutes: number): string {
+  const clamped = Math.max(0, Math.min(totalMinutes, 1439))
+  const h = String(Math.floor(clamped / 60)).padStart(2, "0")
+  const m = String(clamped % 60).padStart(2, "0")
+  return `${h}:${m}`
+}
+
+/** Occupied window [start, end) in minutes for a ride. */
+function rideWindow(ride: {
+  pickup_time: string
+  duration_seconds: number | null
+}): { start: number; end: number } {
+  const start = timeToMinutes(ride.pickup_time)
+  const durationMinutes = Math.ceil(
+    (ride.duration_seconds ?? DEFAULT_RIDE_DURATION_SECONDS) / 60
+  )
+  return { start, end: start + durationMinutes }
+}
+
+/**
+ * The rides that occupy a driver's time relative to the active ride: same
+ * date, requested or confirmed for that driver, and not the active ride itself
+ * or its linked leg (the legs of one trip must not conflict with each other —
+ * co-assigning both to the same driver is exactly the desired outcome).
+ */
+function occupyingRides(
+  driverId: string,
+  activeRide: SplitRide,
+  allRides: readonly SplitRide[]
+): SplitRide[] {
+  return allRides.filter(
+    (r) =>
+      r.driver_id === driverId &&
+      r.date === activeRide.date &&
+      (r.assignmentStatus === "angefragt" ||
+        r.assignmentStatus === "bestaetigt") &&
+      r.id !== activeRide.id &&
+      r.id !== activeRide.parent_ride_id &&
+      r.parent_ride_id !== activeRide.id
+  )
+}
+
+/**
+ * Resolve one driver's context relative to the active ride.
+ *
+ * Precedence when several apply: absence > conflict > outside availability.
+ * An absent driver is blocked outright; a conflicting one shows the concrete
+ * overlapping window (more actionable than the generic availability hint).
+ */
+export function resolveDriverRideContext(
+  activeRide: SplitRide,
+  driver: SplitDriver,
+  allRides: readonly SplitRide[]
+): DriverRideContext {
+  // 1) Approved absence covering the ride date (neutral range, #187).
+  const absence = driver.absences.find(
+    (a) => activeRide.date >= a.start_date && activeRide.date <= a.end_date
+  )
+  if (absence) {
+    return {
+      state: "abwesend",
+      reason: `Nicht verfügbar bis ${formatDayLabel(absence.end_date)}`,
+      assignable: false,
+      needsOverride: false,
+    }
+  }
+
+  // 2) Time conflict with an already requested/confirmed ride that day.
+  const active = rideWindow(activeRide)
+  const conflicting = occupyingRides(driver.id, activeRide, allRides)
+    .map((r) => ({ ride: r, window: rideWindow(r) }))
+    .filter(({ window: w }) => w.start < active.end && active.start < w.end)
+    .sort((a, b) => a.window.start - b.window.start)[0]
+
+  if (conflicting) {
+    return {
+      state: "konflikt",
+      reason: `Fährt bereits ${minutesToTime(
+        conflicting.window.start
+      )}–${minutesToTime(conflicting.window.end)}`,
+      assignable: true,
+      needsOverride: true,
+    }
+  }
+
+  // 3) Availability windows on the ride date (weekly grid + date exceptions).
+  const windows = resolveAvailability(
+    activeRide.date,
+    toAvailabilityEntries([...driver.availability])
+  )
+  if (!isTimeWithinWindows(activeRide.pickup_time, windows)) {
+    return {
+      state: "ausserhalb",
+      reason:
+        windows.length > 0
+          ? `Verfügbar ${formatWindows(windows)}`
+          : "Laut Wochenschema nicht verfügbar",
+      assignable: true,
+      needsOverride: true,
+    }
+  }
+
+  return {
+    state: "verfuegbar",
+    reason: null,
+    assignable: true,
+    needsOverride: false,
+  }
+}
+
+/** "08:00–12:00, 14:00–16:00" */
+function formatWindows(windows: readonly TimeWindow[]): string {
+  return windows
+    .map((w) => `${w.start.slice(0, 5)}–${w.end.slice(0, 5)}`)
+    .join(", ")
+}
+
+/**
+ * Sort drivers for the context view: available first, then conflict, then
+ * outside availability, then absent — alphabetical within each group
+ * (matching the panel's default ordering).
+ */
+export function sortDriversByContext(
+  drivers: readonly SplitDriver[],
+  contextById: ReadonlyMap<string, DriverRideContext>
+): SplitDriver[] {
+  return [...drivers].sort((a, b) => {
+    const rankA = STATE_RANK[contextById.get(a.id)?.state ?? "verfuegbar"]
+    const rankB = STATE_RANK[contextById.get(b.id)?.state ?? "verfuegbar"]
+    if (rankA !== rankB) return rankA - rankB
+    return (
+      a.last_name.localeCompare(b.last_name, "de") ||
+      a.first_name.localeCompare(b.first_name, "de")
+    )
+  })
+}

--- a/src/lib/rides/__tests__/co-assign.test.ts
+++ b/src/lib/rides/__tests__/co-assign.test.ts
@@ -142,10 +142,9 @@ describe("planCoAssignment", () => {
     expect(plan.legs[0]?.requestAcceptance).toBe(false)
   })
 
-  it("keeps a rejected leg's status but re-requests acceptance for a new driver", () => {
-    // A rejected leg stays `rejected` here (no unplanned auto-transition), so it
-    // does not trigger a fresh request — the caller decides how to handle a
-    // rejected linked leg. Guard against accidental status promotion.
+  it("returns a rejected leg to planned and requests acceptance from the new driver", () => {
+    // Re-assignment after a rejection (#169): the state machine allows
+    // rejected -> planned, and the new driver needs a fresh request.
     const plan = planCoAssignment(
       [
         {
@@ -160,9 +159,29 @@ describe("planCoAssignment", () => {
     )
     expect(plan.proceed).toBe(true)
     if (!plan.proceed) return
-    expect(plan.legs[0]?.targetStatus).toBe("rejected")
-    expect(plan.legs[0]?.statusChanged).toBe(false)
+    expect(plan.legs[0]?.targetStatus).toBe("planned")
+    expect(plan.legs[0]?.statusChanged).toBe(true)
     expect(plan.legs[0]?.driverChanged).toBe(true)
-    expect(plan.legs[0]?.requestAcceptance).toBe(false)
+    expect(plan.legs[0]?.requestAcceptance).toBe(true)
+  })
+
+  it("re-requests acceptance when the SAME driver is asked again after rejecting", () => {
+    const plan = planCoAssignment(
+      [
+        {
+          rideId: OUTBOUND,
+          role: "primary",
+          status: "rejected",
+          currentDriverId: DRIVER,
+          isAbsent: false,
+        },
+      ],
+      DRIVER
+    )
+    expect(plan.proceed).toBe(true)
+    if (!plan.proceed) return
+    expect(plan.legs[0]?.targetStatus).toBe("planned")
+    expect(plan.legs[0]?.driverChanged).toBe(false)
+    expect(plan.legs[0]?.requestAcceptance).toBe(true)
   })
 })

--- a/src/lib/rides/co-assign.ts
+++ b/src/lib/rides/co-assign.ts
@@ -136,10 +136,13 @@ export function planCoAssignment(
   }
 
   const planned: PlannedLeg[] = legs.map((leg) => {
-    // Mirror the single-assign auto-transition: an unplanned leg with no driver
-    // becomes `planned` when a driver is set. Any other status is preserved.
+    // Mirror the single-assign auto-transitions: an unplanned leg with no
+    // driver becomes `planned` when a driver is set, and a `rejected` leg
+    // returns to `planned` on re-assignment (state machine: rejected ->
+    // planned, #169). Any other status is preserved.
     const targetStatus: RideStatus =
-      leg.status === "unplanned" && !leg.currentDriverId
+      (leg.status === "unplanned" && !leg.currentDriverId) ||
+      leg.status === "rejected"
         ? "planned"
         : leg.status
 
@@ -151,9 +154,12 @@ export function planCoAssignment(
       targetStatus,
       statusChanged: targetStatus !== leg.status,
       driverChanged,
-      // A fresh request is needed when we newly (re)assign the driver and the
-      // leg is in the `planned` state awaiting acceptance.
-      requestAcceptance: driverChanged && targetStatus === "planned",
+      // A fresh request is needed when the leg ends up `planned` awaiting
+      // acceptance AND either the driver is new or the previous request was
+      // declined (re-requesting the same driver after a rejection).
+      requestAcceptance:
+        targetStatus === "planned" &&
+        (driverChanged || leg.status === "rejected"),
     }
   })
 


### PR DESCRIPTION
Closes #169 (M15 Phase 15.2, baut auf #168 Split-View-Grundgeruest und #167 Rueckfahrt-Mitanfrage auf).

## Was ist neu

**Kontext-Filterung (Konzept §2.2):** Klickt die Dispo links eine Fahrt an, sortiert das Fahrer-Panel automatisch um — verfuegbare Fahrer (im Verfuegbarkeitsfenster, ohne Zeitkonflikt) zuoberst, alle anderen ausgegraut **mit Grund**:

| Zustand | Anzeige | Zuweisbar? |
|---|---|---|
| Verfuegbar | gruen, [Zuweisen] | direkt |
| Konflikt | «Faehrt bereits 08:00–09:00» | hinter «Trotzdem zuweisen»-Rueckfrage |
| Ausserhalb | «Verfuegbar 08:00–12:00» bzw. «Laut Wochenschema nicht verfuegbar» | hinter Rueckfrage |
| Abwesend | «Nicht verfuegbar bis 20.07.» (neutral, #187) | nein — Server-Guard (#182) wuerde ohnehin ablehnen |

**Zuweisen-Flow (Konzept §2.3):** [Zuweisen] → Bestaetigungsdialog «Fahrt anfragen?» mit Fahrtdetails und — wenn eine verknuepfte Rueckfahrt existiert — Checkbox «Rueckfahrt HH:MM Uhr mit anfragen» (Standard: aktiviert) → `assignDriver` bzw. `assignDriverWithReturn` (#167). Primaerer Button bewusst **«Anfrage senden»** (Bestaetigungspflicht, Konzept §3.1). Feedback via Toast inkl. Sonderfall «Rueckfahrt nicht mehr zuweisbar».

## Technische Punkte

- **Neues Pure-Modul** `src/lib/dispatch/driver-context.ts` (Zustand + Grund + Sortierung, 11 Unit-Tests). Konfliktfenster wie `detectTimeConflicts` ([pickup, pickup+duration], 60-min-Fallback); das verknuepfte Hin-/Rueckfahrt-Leg zaehlt nicht als Konflikt (Co-Zuweisung ist das Ziel).
- **Datenminimierung #187 im Wire-Format:** `SplitDriver.absences` enthaelt nur neutrale Datumsbereiche — der Absenz-Typ verlaesst den Server gar nicht erst.
- **`rejected → planned` bei Neuzuweisung** in `assignDriver` + `planCoAssignment`: Die Statemachine erlaubt die Transition seit je, die Actions machten sie aber nicht — eine Neuzuweisung ab Abgelehnt-Karte haette den Status `rejected` behalten und **keine neue Anfrage-Mail/Tracking ausgeloest**. Jetzt loest sie den regulaeren Request-Flow aus (auch bei erneuter Anfrage an denselben Fahrer). Bestehender Co-Assign-Test war auf das alte Verhalten fixiert und wurde angepasst.

## Tests

- `driver-context.test.ts` neu (11 Tests), `co-assign.test.ts` erweitert (13 Tests)
- Gesamtsuite: 1114 Tests gruen · `tsc --noEmit` sauber · `next build` erfolgreich

🤖 Generated with [Claude Code](https://claude.com/claude-code)