### PR TITLE
feat(m15): Drag & Drop Zuweisung Fahrt auf Fahrer (#170)

### DIFF
--- a/src/components/dispatch/driver-card.tsx
+++ b/src/components/dispatch/driver-card.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useRef, useState } from "react"
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -19,6 +20,12 @@ interface DriverCardProps {
   onAssign?: (driver: SplitDriver) => void
   /** Disables the assign button while a request is in flight. */
   assignPending?: boolean
+  /**
+   * Desktop drag & drop (#170): true while a ride card is being dragged.
+   * Assignable cards become drop targets (same flow as [Zuweisen]); absent
+   * drivers reject the drop natively (`not-allowed` cursor, no dialog).
+   */
+  dropActive?: boolean
 }
 
 /**
@@ -38,21 +45,71 @@ export function DriverCard({
   context = null,
   onAssign,
   assignPending = false,
+  dropActive = false,
 }: DriverCardProps) {
   const availableToday = !driver.is_absent_today && driver.today_slots.length > 0
+  const [isDragOver, setIsDragOver] = useState(false)
+  // dragenter/dragleave also fire for child elements — balance them with a
+  // counter so the highlight doesn't flicker while moving over the card.
+  const dragDepth = useRef(0)
 
   // Card tint: with context it encodes the context state, otherwise today's
   // availability (grundgerüst behavior).
   const highlighted = context ? context.state === "verfuegbar" : availableToday
 
+  // Drop target only while a ride drag is in progress AND this driver is
+  // assignable for it (#170). Absent drivers stay non-targets: without
+  // preventDefault the browser shows the «not allowed» cursor and drop
+  // never fires — no parallel assign path, no dialog.
+  const isDropTarget = dropActive && context?.assignable === true && !!onAssign
+
   return (
     <div
+      onDragOver={
+        isDropTarget
+          ? (e) => {
+              e.preventDefault()
+              e.dataTransfer.dropEffect = "move"
+            }
+          : undefined
+      }
+      onDragEnter={
+        isDropTarget
+          ? () => {
+              dragDepth.current += 1
+              setIsDragOver(true)
+            }
+          : undefined
+      }
+      onDragLeave={
+        isDropTarget
+          ? () => {
+              dragDepth.current -= 1
+              if (dragDepth.current <= 0) {
+                dragDepth.current = 0
+                setIsDragOver(false)
+              }
+            }
+          : undefined
+      }
+      onDrop={
+        isDropTarget
+          ? (e) => {
+              e.preventDefault()
+              dragDepth.current = 0
+              setIsDragOver(false)
+              onAssign?.(driver)
+            }
+          : undefined
+      }
       className={cn(
         "flex items-center justify-between gap-2 rounded-md border px-3 py-2",
         highlighted
           ? "border-green-200 bg-green-50"
           : "border-gray-200 bg-gray-50",
-        context && !context.assignable && "opacity-60"
+        context && !context.assignable && "opacity-60",
+        isDropTarget && "transition-shadow",
+        isDragOver && "ring-2 ring-primary"
       )}
     >
       <div className="flex min-w-0 flex-col">

--- a/src/components/dispatch/driver-column.tsx
+++ b/src/components/dispatch/driver-column.tsx
@@ -37,6 +37,11 @@ interface DriverColumnProps {
   activeRide: SplitRide | null
   /** Called after a successful assignment (parent clears the selection). */
   onAssigned?: () => void
+  /**
+   * True while a ride card is being dragged (#170). Assignable driver cards
+   * become drop targets; a drop enters the SAME dialog flow as [Zuweisen].
+   */
+  dragActive?: boolean
 }
 
 /** "HH:MM:SS" | "HH:MM" -> "HH:MM". */
@@ -62,6 +67,7 @@ export function DriverColumn({
   rides,
   activeRide,
   onAssigned,
+  dragActive = false,
 }: DriverColumnProps) {
   const { toast } = useToast()
   const [isPending, startTransition] = useTransition()
@@ -220,6 +226,7 @@ export function DriverColumn({
                 context={activeRide ? contextById.get(driver.id) ?? null : null}
                 onAssign={assignMode ? handleAssignClick : undefined}
                 assignPending={isPending}
+                dropActive={dragActive && assignMode}
               />
             ))
           )}

--- a/src/components/dispatch/ride-card.tsx
+++ b/src/components/dispatch/ride-card.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useState } from "react"
 import { CornerDownLeft, AlertTriangle } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
@@ -53,23 +54,36 @@ interface RideCardProps {
   isSelected: boolean
   onSelect: (rideId: string) => void
   onOpenDetail: (rideId: string) => void
+  /**
+   * Desktop drag & drop (#170): when true, the card can be dragged onto a
+   * driver card. Purely additive — selection + click flow stay fully usable
+   * (touch/keyboard never see this affordance).
+   */
+  draggable?: boolean
+  onDragStart?: (rideId: string) => void
+  onDragEnd?: () => void
 }
 
 /**
- * A single ride card in the split-view left column (M15, #168).
+ * A single ride card in the split-view left column (M15, #168–#170).
  *
- * Display + selection only. Clicking the card ACTIVATES the ride (the docking
- * point for context-filtering the driver panel in #169). A dedicated "Details"
- * button opens the existing `RideQuickSheet`. The `[Zuweisen]` button, drag
- * handle and live countdown are intentionally out of scope here (#169/#170/#171).
+ * Clicking the card ACTIVATES the ride (context-filtering + assign flow in the
+ * driver panel, #169). On desktop the card is additionally draggable onto a
+ * driver card (#170) — dropping it opens the SAME confirm dialog as the click
+ * flow. A dedicated "Details" button opens the existing `RideQuickSheet`.
+ * The live countdown is intentionally out of scope here (#171).
  */
 export function RideCard({
   ride,
   isSelected,
   onSelect,
   onOpenDetail,
+  draggable = false,
+  onDragStart,
+  onDragEnd,
 }: RideCardProps) {
   const isReturn = ride.parent_ride_id !== null
+  const [isDragging, setIsDragging] = useState(false)
 
   return (
     <div
@@ -83,10 +97,33 @@ export function RideCard({
           onSelect(ride.id)
         }
       }}
+      draggable={draggable}
+      onDragStart={
+        draggable
+          ? (e) => {
+              // Firefox needs data for the drag to start; the actual payload
+              // travels via React state (drag start activates the ride).
+              e.dataTransfer.setData("text/plain", ride.id)
+              e.dataTransfer.effectAllowed = "move"
+              setIsDragging(true)
+              onDragStart?.(ride.id)
+            }
+          : undefined
+      }
+      onDragEnd={
+        draggable
+          ? () => {
+              setIsDragging(false)
+              onDragEnd?.()
+            }
+          : undefined
+      }
       className={cn(
         "cursor-pointer rounded-lg border border-l-4 bg-card p-4 shadow-sm transition-colors hover:bg-muted/50",
         ASSIGNMENT_STATUS_BORDER_COLORS[ride.assignmentStatus],
-        isSelected && "ring-2 ring-primary ring-offset-2"
+        isSelected && "ring-2 ring-primary ring-offset-2",
+        draggable && "cursor-grab active:cursor-grabbing",
+        isDragging && "opacity-50"
       )}
     >
       {/* Row 1: date + time · status badge (+ overdue marker) */}

--- a/src/components/dispatch/ride-column.tsx
+++ b/src/components/dispatch/ride-column.tsx
@@ -18,6 +18,10 @@ interface RideColumnProps {
   selectedRideId: string | null
   onSelectRide: (rideId: string) => void
   onOpenDetail: (rideId: string) => void
+  /** Desktop drag & drop (#170): cards in assignable buckets become draggable. */
+  dragEnabled?: boolean
+  onRideDragStart?: (rideId: string) => void
+  onRideDragEnd?: () => void
 }
 
 /**
@@ -36,6 +40,9 @@ export function RideColumn({
   selectedRideId,
   onSelectRide,
   onOpenDetail,
+  dragEnabled = false,
+  onRideDragStart,
+  onRideDragEnd,
 }: RideColumnProps) {
   const counts = useMemo(() => {
     const c: Record<AssignmentStatus, number> = {
@@ -102,6 +109,15 @@ export function RideColumn({
               isSelected={selectedRideId === ride.id}
               onSelect={onSelectRide}
               onOpenDetail={onOpenDetail}
+              // Only rides still looking for a driver are draggable (#170) —
+              // matching the buckets the [Zuweisen] flow serves (#169).
+              draggable={
+                dragEnabled &&
+                (ride.assignmentStatus === "offen" ||
+                  ride.assignmentStatus === "abgelehnt")
+              }
+              onDragStart={onRideDragStart}
+              onDragEnd={onRideDragEnd}
             />
           ))}
         </div>

--- a/src/components/dispatch/split-view.tsx
+++ b/src/components/dispatch/split-view.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useState } from "react"
 import { RideColumn } from "@/components/dispatch/ride-column"
 import { DriverColumn } from "@/components/dispatch/driver-column"
 import { RideQuickSheet } from "@/components/rides/ride-quick-sheet"
+import { useIsPointerFine } from "@/hooks/use-pointer-fine"
 import { ASSIGNMENT_STATUS_ORDER, type AssignmentStatus } from "@/lib/dispatch/assignment-status"
 import type {
   SplitRide,
@@ -25,8 +26,9 @@ interface SplitViewProps {
  *     the selection so the panel returns to its neutral state.
  *
  * A separate `detailRideId` drives the existing `RideQuickSheet` (ride detail).
- * Drag & drop and the live countdown are deliberately absent here — they land
- * in #170/#171.
+ * Desktop drag & drop (#170) is additive on top: dragging a ride activates it
+ * and a drop on a driver card enters the same dialog flow as [Zuweisen].
+ * The live countdown is deliberately absent here — it lands in #171.
  */
 export function SplitView({ rides, drivers }: SplitViewProps) {
   // Default to the first tab (in order) that actually has rides, else "offen".
@@ -39,10 +41,26 @@ export function SplitView({ rides, drivers }: SplitViewProps) {
   const [selectedRideId, setSelectedRideId] = useState<string | null>(null)
   const [detailRideId, setDetailRideId] = useState<string | null>(null)
   const [sheetOpen, setSheetOpen] = useState(false)
+  // Desktop drag & drop (#170): only offered on fine-pointer devices; the
+  // click flow (#169) stays the complete, keyboard-accessible path everywhere.
+  const dragEnabled = useIsPointerFine()
+  const [draggingRideId, setDraggingRideId] = useState<string | null>(null)
 
   const handleSelectRide = useCallback((rideId: string) => {
     // Toggle: clicking the active ride again de-selects it.
     setSelectedRideId((current) => (current === rideId ? null : rideId))
+  }, [])
+
+  const handleRideDragStart = useCallback((rideId: string) => {
+    // Dragging ACTIVATES the ride (no toggle) so the driver panel shows the
+    // context for exactly the card in hand — and the drop can reuse the
+    // active-ride assign flow unchanged.
+    setSelectedRideId(rideId)
+    setDraggingRideId(rideId)
+  }, [])
+
+  const handleRideDragEnd = useCallback(() => {
+    setDraggingRideId(null)
   }, [])
 
   const handleOpenDetail = useCallback((rideId: string) => {
@@ -65,12 +83,16 @@ export function SplitView({ rides, drivers }: SplitViewProps) {
           selectedRideId={selectedRideId}
           onSelectRide={handleSelectRide}
           onOpenDetail={handleOpenDetail}
+          dragEnabled={dragEnabled}
+          onRideDragStart={handleRideDragStart}
+          onRideDragEnd={handleRideDragEnd}
         />
         <DriverColumn
           drivers={drivers}
           rides={rides}
           activeRide={activeRide}
           onAssigned={() => setSelectedRideId(null)}
+          dragActive={draggingRideId !== null}
         />
       </div>
 

--- a/src/hooks/use-pointer-fine.ts
+++ b/src/hooks/use-pointer-fine.ts
@@ -1,0 +1,25 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+/**
+ * Whether the primary input is a fine pointer (mouse/trackpad), via the
+ * `(pointer: fine)` media query. Used to offer drag & drop only on desktop
+ * (M15, #170) — on touch devices the click flow stays the one and only path.
+ *
+ * Starts as `false` (SSR-safe) and resolves after mount, so touch devices
+ * never see a drag affordance flash.
+ */
+export function useIsPointerFine(): boolean {
+  const [fine, setFine] = useState(false)
+
+  useEffect(() => {
+    const mq = window.matchMedia("(pointer: fine)")
+    setFine(mq.matches)
+    const onChange = (e: MediaQueryListEvent) => setFine(e.matches)
+    mq.addEventListener("change", onChange)
+    return () => mq.removeEventListener("change", onChange)
+  }, [])
+
+  return fine
+}


### PR DESCRIPTION
Closes #170 (M15 Phase 15.2). **Stacked auf #199** (#169 Kontext-Filterung + Zuweisen-Flow) — bitte nach #199 mergen; GitHub retargetet die Base dann automatisch auf `main`.

## Was ist neu

Native HTML5-Drag&Drop, rein additiv zum Klick-Flow (Konzept §2.3: beide Wege, ein Ergebnis):

- **Fahrt-Karten in den Buckets Offen/Abgelehnt sind draggable** (nur diese — dieselben Buckets, die der [Zuweisen]-Flow bedient). Drag-Ghost + `opacity-50` auf der Quelle, `cursor-grab`.
- **Drag aktiviert die Fahrt** — die Kontext-Filterung des Fahrer-Panels (#169) laeuft waehrend des Drags live mit, die Dispo sieht beim Ziehen sofort, wer verfuegbar ist.
- **Drop auf eine zuweisbare Fahrer-Karte** (Ring-Highlight beim Hover) oeffnet **denselben Bestaetigungsdialog** wie [Zuweisen] inkl. Rueckfahrt-Checkbox — keine parallele Assign-Logik, ein einziger Codepfad bis zur Server Action.
- **Abwesende Fahrer sind keine Drop-Ziele**: kein `preventDefault` → Browser zeigt den «not allowed»-Cursor, Drop feuert nie, kein Dialog. Der Grund steht bereits auf der Karte («Nicht verfuegbar bis …»).
- **Nur Desktop**: Drag wird nur auf `(pointer: fine)`-Geraeten angeboten (neuer Hook `useIsPointerFine`, SSR-safe). Auf Touch bleibt der Klick-Flow der einzige Pfad.
- **Barrierefreiheit**: rein additiv — Auswahl, [Zuweisen] und Dialoge bleiben vollstaendig per Tastatur bedienbar.

Keine neue Abhaengigkeit (kein dnd-kit o.ae.), keine DB-/Action-Aenderungen.

## Tests

`tsc --noEmit` sauber · ESLint sauber · `next build` erfolgreich. Die DnD-Interaktion selbst ist Browser-Verhalten (HTML5-DnD ist in jsdom nicht sinnvoll testbar); die gesamte darunterliegende Assign-Logik ist durch die #169-Tests abgedeckt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)