### PR TITLE
feat(m15): Live-Countdown auf Angefragt-Karten + Abgelehnt-Ruecksprung (#171)

### DIFF
--- a/src/app/(dashboard)/dispatch/page.tsx
+++ b/src/app/(dashboard)/dispatch/page.tsx
@@ -216,10 +216,10 @@ async function renderSplitView(weekStart: string, today: string) {
     const destination = r.destinations as { display_name: string } | null
 
     const tracking = trackingByRideId.get(r.id) ?? null
-    const overdue =
+    const timing =
       assignmentStatus === "angefragt"
-        ? deriveAngefragtTiming(tracking, now).overdue
-        : false
+        ? deriveAngefragtTiming(tracking, now)
+        : null
 
     const rejection = rejectionByRideId.get(r.id)
 
@@ -242,7 +242,9 @@ async function renderSplitView(weekStart: string, today: string) {
         ? driverNameById.get(r.driver_id) ?? null
         : null,
       linked_return_time: returnByParentId.get(r.id) ?? null,
-      overdue,
+      overdue: timing?.overdue ?? false,
+      next_deadline_at: timing?.dueAt?.toISOString() ?? null,
+      next_deadline_stage: timing?.nextStage ?? null,
       rejected_by_name:
         assignmentStatus === "abgelehnt" && rejection?.driver_id
           ? driverNameById.get(rejection.driver_id) ?? null

--- a/src/components/dispatch/acceptance-countdown.tsx
+++ b/src/components/dispatch/acceptance-countdown.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { AlertTriangle, Timer } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import {
+  formatRemaining,
+  deadlineStageLabel,
+} from "@/lib/dispatch/countdown-format"
+
+/** Tick once per 30s — minute-granularity display needs no faster cadence. */
+const TICK_MS = 30_000
+
+interface AcceptanceCountdownProps {
+  /** ISO instant of the next SLA deadline, or null when none is pending. */
+  dueAt: string | null
+  /** What the deadline escalates to (tooltip label). */
+  nextStage: "reminder_1" | "timed_out" | null
+  /** Server-side overdue snapshot — the pre-hydration and no-deadline state. */
+  initialOverdue: boolean
+}
+
+/**
+ * Live countdown on «Angefragt» ride cards (M15, #171, concept §2.1/§3.3).
+ *
+ * Shows the remaining time until the next SLA deadline («⏱ 18h»). The deadline
+ * itself is computed SERVER-side via the shared `nextDeadline` function (single
+ * source of truth with the cron engine, #165) and shipped as an absolute
+ * instant — the client only renders the delta, so UI and escalation always
+ * agree. When the deadline passes without a reload the badge flips to
+ * «Überfällig» instead of counting into negative time.
+ *
+ * Hydration: the remaining time is only computed after mount (`remainingMs`
+ * starts null); until then the server-provided `initialOverdue` decides which
+ * badge shape renders. This keeps SSR and first client render identical.
+ */
+export function AcceptanceCountdown({
+  dueAt,
+  nextStage,
+  initialOverdue,
+}: AcceptanceCountdownProps) {
+  const [remainingMs, setRemainingMs] = useState<number | null>(null)
+
+  useEffect(() => {
+    if (!dueAt) return
+    const dueMs = new Date(dueAt).getTime()
+    const update = () => setRemainingMs(dueMs - Date.now())
+    update()
+    const interval = setInterval(update, TICK_MS)
+    return () => clearInterval(interval)
+  }, [dueAt])
+
+  // No pending deadline: either already escalated (timed_out → «Überfällig»)
+  // or there is no active tracking at all (nothing to show).
+  if (!dueAt) {
+    return initialOverdue ? <OverdueBadge /> : null
+  }
+
+  const overdue = remainingMs !== null ? remainingMs <= 0 : initialOverdue
+  if (overdue) {
+    return <OverdueBadge />
+  }
+
+  const title = nextStage
+    ? `Frist bis ${deadlineStageLabel(nextStage)}: ${new Date(
+        dueAt
+      ).toLocaleString("de-CH", {
+        day: "2-digit",
+        month: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+      })}`
+    : undefined
+
+  return (
+    <Badge
+      variant="outline"
+      className="border-amber-300 bg-amber-50 tabular-nums text-amber-800"
+      title={title}
+      aria-label={
+        remainingMs !== null
+          ? `Antwortfrist: noch ${formatRemaining(remainingMs)}`
+          : "Antwortfrist läuft"
+      }
+    >
+      <Timer className="mr-1 h-3 w-3" aria-hidden="true" />
+      {remainingMs !== null ? formatRemaining(remainingMs) : "…"}
+    </Badge>
+  )
+}
+
+/** «Überfällig» marker — deadline passed or already escalated (concept §3.3). */
+function OverdueBadge() {
+  return (
+    <Badge variant="outline" className="border-red-300 bg-red-50 text-red-700">
+      <AlertTriangle className="mr-1 h-3 w-3" aria-hidden="true" />
+      Überfällig
+    </Badge>
+  )
+}

--- a/src/components/dispatch/ride-card.tsx
+++ b/src/components/dispatch/ride-card.tsx
@@ -1,10 +1,11 @@
 "use client"
 
 import { useState } from "react"
-import { CornerDownLeft, AlertTriangle } from "lucide-react"
+import { CornerDownLeft } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import { AssignmentStatusBadge } from "@/components/dispatch/assignment-status-badge"
+import { AcceptanceCountdown } from "@/components/dispatch/acceptance-countdown"
 import { ASSIGNMENT_STATUS_BORDER_COLORS } from "@/lib/dispatch/assignment-status"
 import {
   RIDE_REQUIREMENT_LABELS,
@@ -132,14 +133,13 @@ export function RideCard({
           {formatDayLabel(ride.date)} {"·"} {formatTime(ride.pickup_time)}
         </span>
         <div className="flex items-center gap-1.5">
-          {ride.assignmentStatus === "angefragt" && ride.overdue && (
-            <Badge
-              variant="outline"
-              className="border-red-300 bg-red-50 text-red-700"
-            >
-              <AlertTriangle className="mr-1 h-3 w-3" aria-hidden="true" />
-              Überfällig
-            </Badge>
+          {/* Live-Countdown bis zur nächsten SLA-Frist bzw. «Überfällig» (#171). */}
+          {ride.assignmentStatus === "angefragt" && (
+            <AcceptanceCountdown
+              dueAt={ride.next_deadline_at}
+              nextStage={ride.next_deadline_stage}
+              initialOverdue={ride.overdue}
+            />
           )}
           {isReturn && (
             <Badge variant="outline" className="text-xs">

--- a/src/components/dispatch/ride-column.tsx
+++ b/src/components/dispatch/ride-column.tsx
@@ -26,12 +26,16 @@ interface RideColumnProps {
 
 /**
  * Left column of the split-view: status tabs with counters + the filtered ride
- * list (M15, #168).
+ * list (M15, #168/#171).
  *
  * Exactly four buckets (concept §0). The "Abgelehnt" tab is only rendered when
  * its count > 0 (reduces noise on quiet days, Kim §2); the other three are
- * always visible even at 0. No "Alle" tab — the four buckets are complete and
- * non-overlapping for the assignment question.
+ * always visible even at 0. No "Alle" tab.
+ *
+ * Rejected rides «spring back» into the Offen view (#171, concept §2.1/§3.2):
+ * the Offen tab additionally shows them PINNED ON TOP with their ⛔ note, ready
+ * for reassignment — its counter includes them (it counts actionable rides).
+ * The dedicated Abgelehnt tab stays as the focused filter view.
  */
 export function RideColumn({
   rides,
@@ -52,13 +56,24 @@ export function RideColumn({
       abgelehnt: 0,
     }
     for (const ride of rides) c[ride.assignmentStatus]++
+    // Offen counts everything needing (re)assignment — incl. rejected rides,
+    // which are pinned into the Offen view (#171).
+    c.offen += c.abgelehnt
     return c
   }, [rides])
 
-  const visibleRides = useMemo(
-    () => rides.filter((r) => r.assignmentStatus === activeTab),
-    [rides, activeTab]
-  )
+  const visibleRides = useMemo(() => {
+    // «Abgelehnt springt zurück auf Offen» (#171): the Offen tab shows the
+    // rejected rides first (most urgent — a driver just bailed), then the
+    // regular open rides. Both groups keep their date/time order.
+    if (activeTab === "offen") {
+      return [
+        ...rides.filter((r) => r.assignmentStatus === "abgelehnt"),
+        ...rides.filter((r) => r.assignmentStatus === "offen"),
+      ]
+    }
+    return rides.filter((r) => r.assignmentStatus === activeTab)
+  }, [rides, activeTab])
 
   return (
     <div className="space-y-4">

--- a/src/components/dispatch/split-view-types.ts
+++ b/src/components/dispatch/split-view-types.ts
@@ -43,10 +43,19 @@ export interface SplitRide {
   /** Pickup time of the linked return ride, if any ("↩ Rückfahrt 11:00"). */
   linked_return_time: string | null
   /**
-   * Whether the acceptance request is past its next SLA deadline. Static
-   * server snapshot — the live countdown is Issue #171.
+   * Whether the acceptance request is past its next SLA deadline at request
+   * time. Initial SSR value — the live countdown (#171) keeps ticking client-
+   * side and flips to «Überfällig» without a reload.
    */
   overdue: boolean
+  /**
+   * Absolute instant (ISO) of the next SLA deadline, computed via the shared
+   * `nextDeadline` single source of truth. Null when no deadline is pending
+   * (no active tracking, or already timed out).
+   */
+  next_deadline_at: string | null
+  /** What that deadline escalates to — labels the countdown tooltip (#171). */
+  next_deadline_stage: "reminder_1" | "timed_out" | null
   /** Driver who declined (Abgelehnt cards). */
   rejected_by_name: string | null
   /** When the decline happened (ISO). */

--- a/src/lib/dispatch/__tests__/assignment-status.test.ts
+++ b/src/lib/dispatch/__tests__/assignment-status.test.ts
@@ -86,7 +86,11 @@ describe("deriveAngefragtTiming — SLA overdue marker (reuses nextDeadline)", (
   const NOTIFIED = "2026-07-16T08:00:00.000Z"
 
   it("no tracking → not overdue, no deadline", () => {
-    expect(deriveAngefragtTiming(null)).toEqual({ overdue: false, dueAt: null })
+    expect(deriveAngefragtTiming(null)).toEqual({
+      overdue: false,
+      dueAt: null,
+      nextStage: null,
+    })
   })
 
   it("fresh 'notified' before the reminder window → pending, not overdue", () => {
@@ -101,6 +105,21 @@ describe("deriveAngefragtTiming — SLA overdue marker (reuses nextDeadline)", (
     expect(timing.overdue).toBe(false)
     // dueAt = notified + 24h (normal reminder window).
     expect(timing.dueAt?.toISOString()).toBe("2026-07-17T08:00:00.000Z")
+    expect(timing.nextStage).toBe("reminder_1")
+  })
+
+  it("'reminder_1' stage counts down to the dispatcher alarm (timed_out)", () => {
+    const tracking: DeadlineInput = {
+      stage: "reminder_1",
+      is_short_notice: false,
+      notified_at: NOTIFIED,
+    }
+    const now = new Date("2026-07-17T09:00:00.000Z")
+    const timing = deriveAngefragtTiming(tracking, now)
+    // dueAt = notified + 48h (normal timeout window).
+    expect(timing.dueAt?.toISOString()).toBe("2026-07-18T08:00:00.000Z")
+    expect(timing.nextStage).toBe("timed_out")
+    expect(timing.overdue).toBe(false)
   })
 
   it("'notified' past the reminder window → overdue", () => {
@@ -136,6 +155,7 @@ describe("deriveAngefragtTiming — SLA overdue marker (reuses nextDeadline)", (
     expect(deriveAngefragtTiming(tracking)).toEqual({
       overdue: true,
       dueAt: null,
+      nextStage: null,
     })
   })
 })

--- a/src/lib/dispatch/__tests__/countdown-format.test.ts
+++ b/src/lib/dispatch/__tests__/countdown-format.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest"
+import {
+  formatRemaining,
+  deadlineStageLabel,
+} from "@/lib/dispatch/countdown-format"
+
+const MINUTE = 60_000
+const HOUR = 3_600_000
+
+describe("formatRemaining", () => {
+  it("shows coarse hours from 10h upwards (mockup «⏱ 18h»)", () => {
+    expect(formatRemaining(18 * HOUR)).toBe("18h")
+    expect(formatRemaining(10 * HOUR)).toBe("10h")
+    expect(formatRemaining(47 * HOUR + 59 * MINUTE)).toBe("47h")
+  })
+
+  it("shows hours + minutes between 1h and 10h", () => {
+    expect(formatRemaining(3 * HOUR + 20 * MINUTE)).toBe("3h 20m")
+    expect(formatRemaining(9 * HOUR + 59 * MINUTE)).toBe("9h 59m")
+    expect(formatRemaining(HOUR)).toBe("1h")
+  })
+
+  it("shows minutes below one hour", () => {
+    expect(formatRemaining(45 * MINUTE)).toBe("45m")
+    expect(formatRemaining(MINUTE)).toBe("1m")
+  })
+
+  it("floors sub-minute remainders to <1m instead of 0m", () => {
+    expect(formatRemaining(59_000)).toBe("<1m")
+    expect(formatRemaining(1)).toBe("<1m")
+  })
+
+  it("never emits negative values for the caller-handled expired case", () => {
+    // Callers switch to «Überfällig» at <= 0 — but stay safe on race conditions.
+    expect(formatRemaining(0)).toBe("<1m")
+  })
+})
+
+describe("deadlineStageLabel", () => {
+  it("labels both escalation targets in German", () => {
+    expect(deadlineStageLabel("reminder_1")).toBe("Erinnerung")
+    expect(deadlineStageLabel("timed_out")).toBe("Dispo-Alarm")
+  })
+})

--- a/src/lib/dispatch/__tests__/driver-context.test.ts
+++ b/src/lib/dispatch/__tests__/driver-context.test.ts
@@ -33,6 +33,8 @@ function makeRide(overrides: Partial<SplitRide> = {}): SplitRide {
     assigned_driver_name: null,
     linked_return_time: null,
     overdue: false,
+    next_deadline_at: null,
+    next_deadline_stage: null,
     rejected_by_name: null,
     rejected_at: null,
     ...overrides,

--- a/src/lib/dispatch/assignment-status.ts
+++ b/src/lib/dispatch/assignment-status.ts
@@ -101,6 +101,12 @@ export interface AngefragtTiming {
   overdue: boolean
   /** Absolute instant of the next escalation, or null if none pending. */
   dueAt: Date | null
+  /**
+   * Which escalation the deadline leads to — `reminder_1` (Erinnerungsmail)
+   * or `timed_out` (Dispo-Alarm). Labels the countdown (#171); null when
+   * there is no pending deadline.
+   */
+  nextStage: "reminder_1" | "timed_out" | null
 }
 
 export function deriveAngefragtTiming(
@@ -108,19 +114,21 @@ export function deriveAngefragtTiming(
   now: Date = new Date()
 ): AngefragtTiming {
   if (!tracking) {
-    return { overdue: false, dueAt: null }
+    return { overdue: false, dueAt: null, nextStage: null }
   }
   // Already escalated to timeout: overdue, nothing left to count down to.
   if (tracking.stage === "timed_out") {
-    return { overdue: true, dueAt: null }
+    return { overdue: true, dueAt: null, nextStage: null }
   }
   const deadline = nextDeadline(tracking)
   if (!deadline) {
-    return { overdue: false, dueAt: null }
+    return { overdue: false, dueAt: null, nextStage: null }
   }
   return {
     overdue: now.getTime() >= deadline.dueAt.getTime(),
     dueAt: deadline.dueAt,
+    // nextDeadline only ever escalates to reminder_1 or timed_out (§3.3).
+    nextStage: deadline.nextStage === "reminder_1" ? "reminder_1" : "timed_out",
   }
 }
 

--- a/src/lib/dispatch/countdown-format.ts
+++ b/src/lib/dispatch/countdown-format.ts
@@ -1,0 +1,41 @@
+/**
+ * Countdown display formatting for the Angefragt cards (M15, #171).
+ *
+ * Pure module so the format rules are unit-testable. The countdown shows the
+ * time remaining until the NEXT SLA deadline (reminder or dispatcher alarm),
+ * matching the concept mockup «⏱ 18h» — coarse on purpose: the dispatcher
+ * needs "roughly how long", not seconds.
+ */
+
+const MS_PER_MINUTE = 60_000
+const MS_PER_HOUR = 3_600_000
+
+/**
+ * Format a remaining-time span:
+ *
+ *   >= 10h        → "18h"        (coarse, hours only)
+ *   1h … 10h      → "3h 20m"
+ *   1m … 1h       → "45m"
+ *   below 1 minute → "<1m"
+ *
+ * Callers must handle `ms <= 0` themselves (the card switches to «Überfällig»
+ * instead of showing negative time).
+ */
+export function formatRemaining(ms: number): string {
+  const totalMinutes = Math.floor(ms / MS_PER_MINUTE)
+  if (totalMinutes < 1) return "<1m"
+
+  const hours = Math.floor(ms / MS_PER_HOUR)
+  if (hours >= 10) return `${hours}h`
+
+  const minutes = totalMinutes - hours * 60
+  if (hours >= 1) return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`
+  return `${minutes}m`
+}
+
+/** German label for what the deadline escalates to (tooltip text). */
+export function deadlineStageLabel(
+  nextStage: "reminder_1" | "timed_out"
+): string {
+  return nextStage === "reminder_1" ? "Erinnerung" : "Dispo-Alarm"
+}


### PR DESCRIPTION
Closes #171 (M15 Phase 15.2). Baut auf #168/#169 auf; die Status-Farben aus dem AC existieren seit #168 (zentrale `ASSIGNMENT_STATUS_*`-Token) — dieser PR ergaenzt die noch fehlenden Teile.

## Was ist neu

**Live-Countdown (Konzept §2.1/§3.3):** «Angefragt»-Karten zeigen ein tickendes Badge «⏱ 18h» bis zur naechsten SLA-Frist.

- **Single Source of Truth:** Die Frist wird serverseitig via `nextDeadline` berechnet — exakt dieselbe Funktion wie Cron/Engine (#165) — und als absoluter Zeitpunkt (`next_deadline_at` ISO) serialisiert. Der Client rendert nur das Delta; UI und Eskalation rechnen nie auseinander.
- **Tick 1x/30s** (Minuten-Granularitaet, Konzept-Mockup «⏱ 18h»; Format: `18h` → `3h 20m` → `45m` → `<1m`, pures getestetes Modul `countdown-format.ts`).
- **Fristueberschreitung ohne Reload:** Badge kippt live auf «Ueberfaellig» statt in negative Zeit; `timed_out`-Trackings zeigen direkt «Ueberfaellig».
- **Tooltip** nennt Stufe + Zeitpunkt («Frist bis Erinnerung/Dispo-Alarm: 17.07., 08:00»), `aria-label` fuer Screenreader.
- **Hydration-sicher:** Restzeit wird erst nach Mount berechnet; bis dahin entscheidet der SSR-`overdue`-Snapshot die Badge-Form.

**Abgelehnt-Ruecksprung (Konzept §3.2, AC):** Abgelehnte Fahrten erscheinen **zuoberst in der Offen-Ansicht** mit ihrem ⛔-Vermerk (ein Fahrer ist gerade abgesprungen — dringendste Neuzuweisung). Der Offen-Zaehler zaehlt damit alle handlungsbeduerftigen Fahrten; der dedizierte Abgelehnt-Tab bleibt als fokussierte Filteransicht erhalten.

## Tests

- `assignment-status.test.ts` erweitert (nextStage, reminder_1→timed_out-Kaskade), `countdown-format.test.ts` neu
- Gesamtsuite 1123 Tests gruen · `tsc --noEmit` sauber · ESLint sauber · `next build` erfolgreich

🤖 Generated with [Claude Code](https://claude.com/claude-code)